### PR TITLE
Forward port out patches to new branch

### DIFF
--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelProvider.java
@@ -1,10 +1,17 @@
 package io.vitess.client.grpc.netty;
 
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.vitess.client.grpc.RetryingInterceptor;
 import io.vitess.client.grpc.RetryingInterceptorConfig;
 
 public class DefaultChannelProvider implements NettyChannelProvider {
+  private static final EventLoopGroup ELG = new NioEventLoopGroup(
+      6,
+      new DefaultThreadFactory("vitess-netyy")
+  );
 
   private final RetryingInterceptorConfig config;
 
@@ -15,6 +22,8 @@ public class DefaultChannelProvider implements NettyChannelProvider {
   @Override
   public NettyChannelBuilder getChannelBuilder(String target) {
     return NettyChannelBuilder.forTarget(target)
+        .eventLoopGroup(ELG)
+        .maxInboundMessageSize(16777216)
         .intercept(new RetryingInterceptor(config));
   }
 }


### PR DESCRIPTION
This is only intended to be used for migration, I don't intend to upstream this and it should get deleted soon.

This will allow me to switch all internal usages onto the new shaded build, while preserving the same behavior and then I can make upgrades to connect-sql to not need these patches, and calculate better ELG sizes.

@leoxlin @makmanalp @acharis 

