### PR TITLE
Pluggable error handlers

### DIFF
--- a/java/client/src/main/java/io/vitess/client/Proto.java
+++ b/java/client/src/main/java/io/vitess/client/Proto.java
@@ -32,18 +32,9 @@ import io.vitess.proto.Query.QueryResult;
 import io.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
 import io.vitess.proto.Vtgate.BoundShardQuery;
 import io.vitess.proto.Vtgate.ExecuteEntityIdsRequest.EntityId;
-import io.vitess.proto.Vtrpc.RPCError;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
-import java.sql.SQLInvalidAuthorizationSpecException;
-import java.sql.SQLNonTransientException;
-import java.sql.SQLRecoverableException;
-import java.sql.SQLSyntaxErrorException;
-import java.sql.SQLTimeoutException;
-import java.sql.SQLTransientException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -57,73 +48,19 @@ public class Proto {
 
   public static final Function<byte[], ByteString> BYTE_ARRAY_TO_BYTE_STRING =
       new Function<byte[], ByteString>() {
-        @Override
-        public ByteString apply(byte[] from) {
-          return ByteString.copyFrom(from);
-        }
-      };
+    @Override
+    public ByteString apply(byte[] from) {
+      return ByteString.copyFrom(from);
+    }
+  };
   public static final Function<Map.Entry<byte[], ?>, EntityId> MAP_ENTRY_TO_ENTITY_KEYSPACE_ID =
       new Function<Map.Entry<byte[], ?>, EntityId>() {
-        @Override
-        public EntityId apply(Map.Entry<byte[], ?> entry) {
-          return buildEntityId(entry.getKey(), entry.getValue());
-        }
-      };
-  private static final int MAX_DECIMAL_UNIT = 30;
-
-  /**
-   * Throws the proper SQLException for an error returned by VTGate.
-   *
-   * <p>
-   * Errors returned by Vitess are documented in the
-   * <a href="https://github.com/vitessio/vitess/blob/master/proto/vtrpc.proto">vtrpc proto</a>.
-   */
-  public static void checkError(RPCError error) throws SQLException {
-    if (error != null) {
-      int errno = getErrno(error.getMessage());
-      String sqlState = getSQLState(error.getMessage());
-
-      switch (error.getCode()) {
-        case OK:
-          break;
-        case INVALID_ARGUMENT:
-          throw new SQLSyntaxErrorException(error.toString(), sqlState, errno);
-        case DEADLINE_EXCEEDED:
-          throw new SQLTimeoutException(error.toString(), sqlState, errno);
-        case ALREADY_EXISTS:
-          throw new SQLIntegrityConstraintViolationException(error.toString(), sqlState, errno);
-        case UNAVAILABLE:
-          throw new SQLTransientException(error.toString(), sqlState, errno);
-        case UNAUTHENTICATED:
-          throw new SQLInvalidAuthorizationSpecException(error.toString(), sqlState, errno);
-        case ABORTED:
-          throw new SQLRecoverableException(error.toString(), sqlState, errno);
-        default:
-          throw new SQLNonTransientException("Vitess RPC error: " + error.toString(), sqlState,
-              errno);
-      }
-
-      switch (error.getLegacyCode()) {
-        case SUCCESS_LEGACY:
-          break;
-        case BAD_INPUT_LEGACY:
-          throw new SQLSyntaxErrorException(error.toString(), sqlState, errno);
-        case DEADLINE_EXCEEDED_LEGACY:
-          throw new SQLTimeoutException(error.toString(), sqlState, errno);
-        case INTEGRITY_ERROR_LEGACY:
-          throw new SQLIntegrityConstraintViolationException(error.toString(), sqlState, errno);
-        case TRANSIENT_ERROR_LEGACY:
-          throw new SQLTransientException(error.toString(), sqlState, errno);
-        case UNAUTHENTICATED_LEGACY:
-          throw new SQLInvalidAuthorizationSpecException(error.toString(), sqlState, errno);
-        case NOT_IN_TX_LEGACY:
-          throw new SQLRecoverableException(error.toString(), sqlState, errno);
-        default:
-          throw new SQLNonTransientException("Vitess RPC error: " + error.toString(), sqlState,
-              errno);
-      }
+    @Override
+    public EntityId apply(Map.Entry<byte[], ?> entry) {
+      return buildEntityId(entry.getKey(), entry.getValue());
     }
-  }
+  };
+  private static final int MAX_DECIMAL_UNIT = 30;
 
   /**
    * Extracts the MySQL errno from a Vitess error message, if any.

--- a/java/client/src/main/java/io/vitess/client/RpcClient.java
+++ b/java/client/src/main/java/io/vitess/client/RpcClient.java
@@ -48,6 +48,7 @@ import io.vitess.proto.Vtgate.StreamExecuteKeyRangesRequest;
 import io.vitess.proto.Vtgate.StreamExecuteKeyspaceIdsRequest;
 import io.vitess.proto.Vtgate.StreamExecuteRequest;
 import io.vitess.proto.Vtgate.StreamExecuteShardsRequest;
+import io.vitess.proto.Vtrpc.RPCError;
 
 import java.io.Closeable;
 import java.sql.SQLException;
@@ -245,4 +246,15 @@ public interface RpcClient extends Closeable {
    */
   ListenableFuture<GetSrvKeyspaceResponse> getSrvKeyspace(
       Context ctx, GetSrvKeyspaceRequest request) throws SQLException;
+
+  /**
+   * <p>Checks if a specific RPCError should be converted to an exception and returns the
+   * appropriate exception corresponding to that error.
+   * </p>
+   *
+   * <p>See the
+   * <a href="https://github.com/vitessio/vitess/blob/master/proto/vtrpc.proto">proto</a>
+   * definition for canonical documentation on this VTGate API.
+   */
+  SQLException checkError(RPCError error);
 }

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
@@ -24,11 +24,11 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.CallCredentials;
 import io.grpc.InternalWithLogId;
 import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
 import io.vitess.client.Context;
-import io.vitess.client.Proto;
 import io.vitess.client.RpcClient;
 import io.vitess.client.StreamIterator;
+import io.vitess.client.grpc.error.DefaultErrorHandler;
+import io.vitess.client.grpc.error.ErrorHandler;
 import io.vitess.proto.Query.QueryResult;
 import io.vitess.proto.Vtgate;
 import io.vitess.proto.Vtgate.BeginRequest;
@@ -63,6 +63,7 @@ import io.vitess.proto.Vtgate.StreamExecuteRequest;
 import io.vitess.proto.Vtgate.StreamExecuteResponse;
 import io.vitess.proto.Vtgate.StreamExecuteShardsRequest;
 import io.vitess.proto.Vtgate.StreamExecuteShardsResponse;
+import io.vitess.proto.Vtrpc.RPCError;
 import io.vitess.proto.grpc.VitessGrpc;
 import io.vitess.proto.grpc.VitessGrpc.VitessFutureStub;
 import io.vitess.proto.grpc.VitessGrpc.VitessStub;
@@ -71,13 +72,6 @@ import org.joda.time.Duration;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
-import java.sql.SQLInvalidAuthorizationSpecException;
-import java.sql.SQLNonTransientException;
-import java.sql.SQLRecoverableException;
-import java.sql.SQLSyntaxErrorException;
-import java.sql.SQLTimeoutException;
-import java.sql.SQLTransientException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -91,6 +85,7 @@ public class GrpcClient implements RpcClient {
   private final VitessStub asyncStub;
   private final VitessFutureStub futureStub;
   private final Duration timeout;
+  private final ErrorHandler errorHandler;
 
   public GrpcClient(ManagedChannel channel) {
     this.channel = channel;
@@ -98,6 +93,7 @@ public class GrpcClient implements RpcClient {
     asyncStub = VitessGrpc.newStub(channel);
     futureStub = VitessGrpc.newFutureStub(channel);
     timeout = DEFAULT_TIMEOUT;
+    errorHandler = new DefaultErrorHandler();
   }
 
   public GrpcClient(ManagedChannel channel, Context context) {
@@ -106,6 +102,7 @@ public class GrpcClient implements RpcClient {
     asyncStub = VitessGrpc.newStub(channel);
     futureStub = VitessGrpc.newFutureStub(channel);
     timeout = getContextTimeoutOrDefault(context);
+    errorHandler = new DefaultErrorHandler();
   }
 
   public GrpcClient(ManagedChannel channel, CallCredentials credentials, Context context) {
@@ -114,6 +111,7 @@ public class GrpcClient implements RpcClient {
     asyncStub = VitessGrpc.newStub(channel).withCallCredentials(credentials);
     futureStub = VitessGrpc.newFutureStub(channel).withCallCredentials(credentials);
     timeout = getContextTimeoutOrDefault(context);
+    errorHandler = new DefaultErrorHandler();
   }
 
   private String toChannelId(ManagedChannel channel) {
@@ -195,8 +193,8 @@ public class GrpcClient implements RpcClient {
   @Override
   public StreamIterator<QueryResult> streamExecute(Context ctx, StreamExecuteRequest request)
       throws SQLException {
-    GrpcStreamAdapter<StreamExecuteResponse, QueryResult> adapter =
-        new GrpcStreamAdapter<StreamExecuteResponse, QueryResult>() {
+    ClientStreamAdapter<StreamExecuteResponse, QueryResult> adapter =
+        new ClientStreamAdapter<StreamExecuteResponse, QueryResult>() {
           @Override
           QueryResult getResult(StreamExecuteResponse response) throws SQLException {
             return response.getResult();
@@ -209,8 +207,8 @@ public class GrpcClient implements RpcClient {
   @Override
   public StreamIterator<QueryResult> streamExecuteShards(Context ctx,
       StreamExecuteShardsRequest request) throws SQLException {
-    GrpcStreamAdapter<StreamExecuteShardsResponse, QueryResult> adapter =
-        new GrpcStreamAdapter<StreamExecuteShardsResponse, QueryResult>() {
+    ClientStreamAdapter<StreamExecuteShardsResponse, QueryResult> adapter =
+        new ClientStreamAdapter<StreamExecuteShardsResponse, QueryResult>() {
           @Override
           QueryResult getResult(StreamExecuteShardsResponse response) throws SQLException {
             return response.getResult();
@@ -223,8 +221,8 @@ public class GrpcClient implements RpcClient {
   @Override
   public StreamIterator<QueryResult> streamExecuteKeyspaceIds(Context ctx,
       StreamExecuteKeyspaceIdsRequest request) throws SQLException {
-    GrpcStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult> adapter =
-        new GrpcStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult>() {
+    ClientStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult> adapter =
+        new ClientStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult>() {
           @Override
           QueryResult getResult(StreamExecuteKeyspaceIdsResponse response) throws SQLException {
             return response.getResult();
@@ -237,8 +235,8 @@ public class GrpcClient implements RpcClient {
   @Override
   public StreamIterator<QueryResult> streamExecuteKeyRanges(Context ctx,
       StreamExecuteKeyRangesRequest request) throws SQLException {
-    GrpcStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult> adapter =
-        new GrpcStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult>() {
+    ClientStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult> adapter =
+        new ClientStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult>() {
           @Override
           QueryResult getResult(StreamExecuteKeyRangesResponse response) throws SQLException {
             return response.getResult();
@@ -283,48 +281,19 @@ public class GrpcClient implements RpcClient {
         new ExceptionConverter<GetSrvKeyspaceResponse>(), MoreExecutors.directExecutor());
   }
 
+  @Override
+  public SQLException checkError(RPCError error) {
+    return errorHandler.checkVitessError(error);
+  }
+
   /**
    * Converts an exception from the gRPC framework into the appropriate {@link SQLException}.
    */
-  static SQLException convertGrpcError(Throwable exc) {
-    if (exc instanceof StatusRuntimeException) {
-      StatusRuntimeException sre = (StatusRuntimeException) exc;
-
-      int errno = Proto.getErrno(sre.getMessage());
-      String sqlState = Proto.getSQLState(sre.getMessage());
-
-      switch (sre.getStatus().getCode()) {
-        case INVALID_ARGUMENT:
-          return new SQLSyntaxErrorException(sre.toString(), sqlState, errno, sre);
-        case DEADLINE_EXCEEDED:
-          return new SQLTimeoutException(sre.toString(), sqlState, errno, sre);
-        case ALREADY_EXISTS:
-          return new SQLIntegrityConstraintViolationException(sre.toString(), sqlState, errno, sre);
-        case UNAUTHENTICATED:
-          return new SQLInvalidAuthorizationSpecException(sre.toString(), sqlState, errno, sre);
-        case UNAVAILABLE:
-          return new SQLTransientException(sre.toString(), sqlState, errno, sre);
-        case ABORTED:
-          return new SQLRecoverableException(sre.toString(), sqlState, errno, sre);
-        default: // Covers e.g. UNKNOWN.
-          String advice = "";
-          if (exc.getCause() instanceof java.nio.channels.ClosedChannelException) {
-            advice =
-                "Failed to connect to vtgate. Make sure that vtgate is running and you are using "
-                    + "the correct address. Details: ";
-          }
-          return new SQLNonTransientException(
-              "gRPC StatusRuntimeException: " + advice + exc.toString(), sqlState, errno, exc);
-      }
-    }
-    return new SQLNonTransientException("gRPC error: " + exc.toString(), exc);
-  }
-
-  static class ExceptionConverter<V> implements AsyncFunction<Exception, V> {
+  class ExceptionConverter<V> implements AsyncFunction<Exception, V> {
 
     @Override
     public ListenableFuture<V> apply(Exception exc) throws Exception {
-      throw convertGrpcError(exc);
+      throw errorHandler.convertGrpcError(exc);
     }
   }
 
@@ -358,5 +327,12 @@ public class GrpcClient implements RpcClient {
     }
 
     return context.getTimeout();
+  }
+
+  private abstract class ClientStreamAdapter<V, E> extends GrpcStreamAdapter<V, E> {
+    @Override
+    ErrorHandler getErrorHandler() {
+      return errorHandler;
+    }
   }
 }

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/error/DefaultErrorHandler.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/error/DefaultErrorHandler.java
@@ -1,0 +1,107 @@
+package io.vitess.client.grpc.error;
+
+import io.grpc.StatusRuntimeException;
+import io.vitess.client.Proto;
+import io.vitess.proto.Vtrpc.RPCError;
+
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLInvalidAuthorizationSpecException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientException;
+
+public class DefaultErrorHandler implements ErrorHandler {
+
+  @Override
+  public SQLException checkVitessError(RPCError error) {
+    if (error == null) {
+      return null;
+    }
+
+    int errno = Proto.getErrno(error.getMessage());
+    String sqlState = Proto.getSQLState(error.getMessage());
+
+    switch (error.getCode()) {
+      case OK:
+        break;
+      case INVALID_ARGUMENT:
+        return new SQLSyntaxErrorException(error.toString(), sqlState, errno);
+      case DEADLINE_EXCEEDED:
+        return new SQLTimeoutException(error.toString(), sqlState, errno);
+      case ALREADY_EXISTS:
+        return new SQLIntegrityConstraintViolationException(error.toString(), sqlState, errno);
+      case UNAVAILABLE:
+        return new SQLTransientException(error.toString(), sqlState, errno);
+      case UNAUTHENTICATED:
+        return new SQLInvalidAuthorizationSpecException(error.toString(), sqlState, errno);
+      case ABORTED:
+        return new SQLRecoverableException(error.toString(), sqlState, errno);
+      default:
+        return new SQLNonTransientException("Vitess RPC error: " + error.toString(), sqlState,
+            errno);
+    }
+
+    switch (error.getLegacyCode()) {
+      case SUCCESS_LEGACY:
+        break;
+      case BAD_INPUT_LEGACY:
+        return new SQLSyntaxErrorException(error.toString(), sqlState, errno);
+      case DEADLINE_EXCEEDED_LEGACY:
+        return new SQLTimeoutException(error.toString(), sqlState, errno);
+      case INTEGRITY_ERROR_LEGACY:
+        return new SQLIntegrityConstraintViolationException(error.toString(), sqlState, errno);
+      case TRANSIENT_ERROR_LEGACY:
+        return new SQLTransientException(error.toString(), sqlState, errno);
+      case UNAUTHENTICATED_LEGACY:
+        return new SQLInvalidAuthorizationSpecException(error.toString(), sqlState, errno);
+      case NOT_IN_TX_LEGACY:
+        return new SQLRecoverableException(error.toString(), sqlState, errno);
+      default:
+        return new SQLNonTransientException("Vitess RPC error: " + error.toString(), sqlState,
+            errno);
+    }
+
+    return new SQLNonTransientException("Vitess vtgate error: " + error.toString(), sqlState,
+        errno);
+  }
+
+  @Override
+  public SQLException convertGrpcError(Throwable returnable) {
+    if (returnable instanceof StatusRuntimeException) {
+      StatusRuntimeException sre = (StatusRuntimeException) returnable;
+
+      int errno = Proto.getErrno(sre.getMessage());
+      String sqlState = Proto.getSQLState(sre.getMessage());
+
+      switch (sre.getStatus().getCode()) {
+        case INVALID_ARGUMENT:
+          return new SQLSyntaxErrorException(sre.toString(), sqlState, errno, sre);
+        case DEADLINE_EXCEEDED:
+          return new SQLTimeoutException(sre.toString(), sqlState, errno, sre);
+        case ALREADY_EXISTS:
+          return new SQLIntegrityConstraintViolationException(sre.toString(), sqlState, errno, sre);
+        case UNAUTHENTICATED:
+          return new SQLInvalidAuthorizationSpecException(sre.toString(), sqlState, errno, sre);
+        case UNAVAILABLE:
+          return new SQLTransientException(sre.toString(), sqlState, errno, sre);
+        case ABORTED:
+          return new SQLRecoverableException(sre.toString(), sqlState, errno, sre);
+        default: // Covers e.g. UNKNOWN.
+          String advice = "";
+          if (returnable.getCause() instanceof java.nio.channels.ClosedChannelException) {
+            advice =
+                "Failed to connect to vtgate. Make sure that vtgate is running and you are using "
+                    + "the correct address. Details: ";
+          }
+          return new SQLNonTransientException(
+              "gRPC StatusRuntimeException: " + advice + returnable.toString(), sqlState, errno,
+              returnable);
+      }
+    }
+
+    return new SQLNonTransientException("gRPC error: " + returnable.toString(), returnable);
+  }
+}

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/error/ErrorHandler.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/error/ErrorHandler.java
@@ -1,0 +1,12 @@
+package io.vitess.client.grpc.error;
+
+import io.vitess.proto.Vtrpc.RPCError;
+
+import java.sql.SQLException;
+
+public interface ErrorHandler {
+
+  SQLException checkVitessError(RPCError error);
+
+  SQLException convertGrpcError(Throwable throwable);
+}

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -175,6 +175,11 @@ public class ConnectionProperties {
       "Classname of an implementation of NettyChannelBuilderProvider. If set this class will be "
           + "used to create channels for the GRPC client.", "", null);
 
+  private StringConnectionProperty errorHandlerClass = new StringConnectionProperty(
+      "errorHandlerClass",
+      "Classname of an implementation of ErrorHandler. If set this class will be "
+          + "used to map errors into the appropriate SqlException.", "", null);
+
   // TLS-related configs
   private BooleanConnectionProperty useSSL = new BooleanConnectionProperty(
       Constants.Property.USE_SSL, "Whether this connection should use transport-layer security",
@@ -493,6 +498,14 @@ public class ConnectionProperties {
 
   public void setGrpcChannelProvider(String grpcChannelProviderClassName) {
     this.grpcChannelProvider.setValue(grpcChannelProviderClassName);
+  }
+
+  public String getErrorHandlerClass() {
+    return errorHandlerClass.getValueAsString();
+  }
+
+  public void setErrorHandlerClass(String errorHandlerClass) {
+    this.errorHandlerClass.setValue(errorHandlerClass);
   }
 
   public boolean getUseSSL() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -23,6 +23,8 @@ import io.vitess.client.RefreshableVTGateConnection;
 import io.vitess.client.VTGateConnection;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.client.grpc.RetryingInterceptorConfig;
+import io.vitess.client.grpc.error.DefaultErrorHandler;
+import io.vitess.client.grpc.error.ErrorHandler;
 import io.vitess.client.grpc.netty.DefaultChannelBuilderProvider;
 import io.vitess.client.grpc.netty.NettyChannelBuilderProvider;
 import io.vitess.client.grpc.tls.TlsOptions;
@@ -89,8 +91,7 @@ public class VitessVTGateManager {
                 new TimerTask() {
                   @Override
                   public void run() {
-                    refreshUpdatedSSLConnections(hostInfo,
-                        connection);
+                    refreshUpdatedSSLConnections(hostInfo, connection);
                   }
                 },
                 TimeUnit.SECONDS.toMillis(connection.getRefreshSeconds()),
@@ -188,6 +189,9 @@ public class VitessVTGateManager {
    */
   private static VTGateConnection getVtGateConn(VitessJDBCUrl.HostInfo hostInfo,
       VitessConnection connection) {
+    NettyChannelBuilderProvider channelProvider = getChannelProviderFromProperties(connection);
+    ErrorHandler errorHandler = getErrorHandlerFromProperties(connection);
+
     final Context context = connection.createContext(connection.getTimeout());
     if (connection.getUseSSL()) {
       final String keyStorePath = connection.getKeyStore() != null ? connection.getKeyStore()
@@ -213,11 +217,11 @@ public class VitessVTGateManager {
           .trustAlias(trustAlias);
 
       return new RefreshableVTGateConnection(
-          new GrpcClientFactory(getChannelProviderFromProperties(connection))
+          new GrpcClientFactory(channelProvider, errorHandler)
               .createTls(context, hostInfo.toString(), tlsOptions), keyStorePath, trustStorePath);
     } else {
       return new VTGateConnection(
-          new GrpcClientFactory(getChannelProviderFromProperties(connection))
+          new GrpcClientFactory(channelProvider, errorHandler)
               .create(context, hostInfo.toString()));
     }
   }
@@ -231,6 +235,17 @@ public class VitessVTGateManager {
         conn.getGrpcRetryMaxBackoffMillis(), conn.getGrpcRetryBackoffMultiplier());
   }
 
+  private static ErrorHandler getErrorHandlerFromProperties(
+      VitessConnection connection) {
+    // Skip reflection in default case
+    if (Strings.isNullOrEmpty(connection.getGrpcChannelProvider())) {
+      return new DefaultErrorHandler();
+    }
+
+    Object provider = constructDefault(connection.getErrorHandlerClass());
+    return ((ErrorHandler) provider);
+  }
+
   private static NettyChannelBuilderProvider getChannelProviderFromProperties(
       VitessConnection connection) {
     // Skip reflection in default case
@@ -238,25 +253,26 @@ public class VitessVTGateManager {
       return new DefaultChannelBuilderProvider(getRetryingInterceptorConfig(connection));
     }
 
+    Object provider = constructDefault(connection.getGrpcChannelProvider());
+    return ((NettyChannelBuilderProvider) provider);
+  }
+
+  private static Object constructDefault(String className) {
     try {
-      Class<?> providerClass = Class.forName(connection.getGrpcChannelProvider());
+      Class<?> providerClass = Class.forName(className);
 
       Constructor<?> constructor = providerClass.getConstructor();
 
-      Object provider = constructor.newInstance();
-      return ((NettyChannelBuilderProvider) provider);
+      Object object = constructor.newInstance();
+      return object;
     } catch (ClassNotFoundException cnf) {
-      throw new RuntimeException(String
-          .format("Could not get netty channel provider: %s", connection.getGrpcChannelProvider()),
-          cnf);
+      throw new RuntimeException(String.format("Could not get find class: %s", className), cnf);
     } catch (NoSuchMethodException nsm) {
-      throw new RuntimeException(String
-          .format("Channel provider %s does not have a default constructor!",
-              connection.getGrpcChannelProvider()), nsm);
+      throw new RuntimeException(
+          String.format("%s does not have a default constructor!", className), nsm);
     } catch (IllegalAccessException | InstantiationException | InvocationTargetException exc) {
-      throw new RuntimeException(String
-          .format("Failed to construct channel provider %s", connection.getGrpcChannelProvider()),
-          exc);
+      throw new RuntimeException(
+          String.format("Failed to construct channel provider %s", className), exc);
     }
   }
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -43,7 +43,7 @@ import org.mockito.Mockito;
 
 public class ConnectionPropertiesTest {
 
-  private static final int NUM_PROPS = 40;
+  private static final int NUM_PROPS = 41;
 
   @Test
   public void testReflection() throws Exception {
@@ -150,7 +150,7 @@ public class ConnectionPropertiesTest {
     assertEquals(NUM_PROPS, infos.length);
 
     // Test the expected fields for just 1
-    int indexForFullTest = 3;
+    int indexForFullTest = 4;
     assertEquals("executeType", infos[indexForFullTest].name);
     assertEquals("Query execution type: simple or stream", infos[indexForFullTest].description);
     assertEquals(false, infos[indexForFullTest].required);
@@ -164,17 +164,18 @@ public class ConnectionPropertiesTest {
     // Test that name exists for the others, as a sanity check
     assertEquals("dbName", infos[1].name);
     assertEquals("characterEncoding", infos[2].name);
-    assertEquals("executeType", infos[3].name);
-    assertEquals("functionsNeverReturnBlobs", infos[4].name);
+    assertEquals("errorHandlerClass", infos[3].name);
+    assertEquals("executeType", infos[4].name);
+    assertEquals("functionsNeverReturnBlobs", infos[5].name);
 
-    assertEquals("grpcChannelBuilderProvider", infos[5].name);
-    assertEquals("grpcRetriesEnabled", infos[6].name);
-    assertEquals("grpcRetriesBackoffMultiplier", infos[7].name);
-    assertEquals("grpcRetriesInitialBackoffMillis", infos[8].name);
-    assertEquals("grpcRetriesMaxBackoffMillis", infos[9].name);
-    assertEquals(Constants.Property.INCLUDED_FIELDS, infos[10].name);
-    assertEquals(Constants.Property.TABLET_TYPE, infos[22].name);
-    assertEquals(Constants.Property.TWOPC_ENABLED, infos[30].name);
+    assertEquals("grpcChannelBuilderProvider", infos[6].name);
+    assertEquals("grpcRetriesEnabled", infos[7].name);
+    assertEquals("grpcRetriesBackoffMultiplier", infos[8].name);
+    assertEquals("grpcRetriesInitialBackoffMillis", infos[9].name);
+    assertEquals("grpcRetriesMaxBackoffMillis", infos[10].name);
+    assertEquals(Constants.Property.INCLUDED_FIELDS, infos[11].name);
+    assertEquals(Constants.Property.TABLET_TYPE, infos[23].name);
+    assertEquals(Constants.Property.TWOPC_ENABLED, infos[31].name);
   }
 
   @Test


### PR DESCRIPTION
This adds an `ErrorHandler` interface which is used by the GRPC client to map errors into SQL exceptions. The existing `static` error mapping has been moved to the `DefaultErrorHandler` which gets used by default.

I still need to add the ability to override this interface via the connection properties.

@leoxlin @acharis @makmanalp 