### PR TITLE
Add temporary info logging statement for slow queries.

### DIFF
--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -18,6 +18,11 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.22</version>
+    </dependency>
 
     <dependency>
       <groupId>io.vitess</groupId>


### PR DESCRIPTION
Going to deploy nucleus with this so we can see on the clientside which queries are slow. Also wondering if I should put this at another level. Hikari's usage-duration tracks the time from when the connection is leased from the pool, until to when it's returned. Will be interesting if the slowness isn't contained in the query execution.

Also, I'm not 100% this is what JDBI does because it's all magic so it's hard to read the source code.