### PR TITLE
Revert "Enable keep alive with a 20s ping for vitess grpc connections."

### DIFF
--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
@@ -7,8 +7,6 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.vitess.client.grpc.RetryingInterceptor;
 import io.vitess.client.grpc.RetryingInterceptorConfig;
 
-import java.util.concurrent.TimeUnit;
-
 public class DefaultChannelBuilderProvider implements NettyChannelBuilderProvider {
   private static final EventLoopGroup ELG = new NioEventLoopGroup(
       6,
@@ -26,8 +24,6 @@ public class DefaultChannelBuilderProvider implements NettyChannelBuilderProvide
     return NettyChannelBuilder.forTarget(target)
         .eventLoopGroup(ELG)
         .maxInboundMessageSize(16777216)
-        .keepAliveTime(20, TimeUnit.SECONDS)
-        .keepAliveWithoutCalls(true)
         .intercept(new RetryingInterceptor(config));
   }
 }


### PR DESCRIPTION
Reverts HubSpot/vitess#20

This ended up not being necessary, we thought we had increased the vitess server goaway to 10m but it was still 1min. Changing it to 10m clearly impacted the main latency we were seeing.