### PR TITLE
[Experimental] Use a single grpc per client per connection in the pool.

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
@@ -199,7 +199,13 @@ public class VitessConnection extends ConnectionProperties implements Connection
         }
         closeAllOpenStatements();
       } finally {
-        this.closed = true;
+        try {
+          if (vtGateConnections != null) {
+            vtGateConnections.close();
+          }
+        } finally {
+          this.closed = true;
+        }
       }
     }
   }

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -21,17 +21,15 @@ import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConnection;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.proto.Vtrpc;
-
 import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * Created by naveen.nahata on 29/02/16.
@@ -73,7 +71,7 @@ public class VitessVTGateManagerTest {
     ConcurrentHashMap<String, VTGateConnection> map = (ConcurrentHashMap<String,
         VTGateConnection>) privateMapField
         .get(VitessVTGateManager.class);
-    Assert.assertEquals(4, map.size());
+    Assert.assertEquals(6, map.size());
     VitessVTGateManager.close();
   }
 


### PR DESCRIPTION
It turns out, this isn't actually that hard to change. The current code builds a global static map of vtGateIdentifier -> vtGateConnection and when you ask for a new connection it checks if it already has a connection in that map and if so, it pulls that connection out of the map for you. The local connection object stores an identifier, which is just a concatenation of host, port, etc and that identifier is the key for the global map. This changes the identifier, so that it's unique per connection object by appending the hashcode of the connection passed in.

The hashcode change is simple enough, but since we now have multiple connections we also need to manage their lifecycle. So, I added a close method to the `VtGateConnections` object which is called when the vtgate is closed. 

Finally, I moved around the synchronization of the concurrent hash map, since we're only writing new unique keys on creation, there's no reason for that to be synchronized. All of the synchronized blocks in this class are currently under the global class, which is unnecessary, so I split them out into what makes more sense. The only things that synchronizes on the map now are removing (when closing connections) and replacing vtgateconnections (when refreshing for certs) and then after the synchronize block we close the connections in a background thread.

I'm pretty confident this can work, but it's going to be tricky to get this behind a config flag.