### PR TITLE
Make slow query logger a first class citizen of the vitess client.

### DIFF
--- a/java/client/src/main/java/io/vitess/client/RefreshableVTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/RefreshableVTGateConnection.java
@@ -12,8 +12,8 @@ public class RefreshableVTGateConnection extends VTGateConnection {
   public RefreshableVTGateConnection(RpcClient client,
       String keystorePath,
       String truststorePath,
-      long slowQueryThreshold) {
-    super(client, slowQueryThreshold);
+      long slowQueryThresholdMillis) {
+    super(client, slowQueryThresholdMillis);
     this.keystoreFile = new File(keystorePath);
     this.truststoreFile = new File(truststorePath);
     this.keystoreMtime = this.keystoreFile.exists() ? this.keystoreFile.lastModified() : 0;

--- a/java/client/src/main/java/io/vitess/client/RefreshableVTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/RefreshableVTGateConnection.java
@@ -11,8 +11,9 @@ public class RefreshableVTGateConnection extends VTGateConnection {
 
   public RefreshableVTGateConnection(RpcClient client,
       String keystorePath,
-      String truststorePath) {
-    super(client);
+      String truststorePath,
+      long slowQueryThreshold) {
+    super(client, slowQueryThreshold);
     this.keystoreFile = new File(keystorePath);
     this.truststoreFile = new File(truststorePath);
     this.keystoreMtime = this.keystoreFile.exists() ? this.keystoreFile.lastModified() : 0;

--- a/java/client/src/main/java/io/vitess/client/VTGateBlockingConnection.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateBlockingConnection.java
@@ -58,7 +58,7 @@ public final class VTGateBlockingConnection implements Closeable {
    * @param client RPC connection
    */
   public VTGateBlockingConnection(RpcClient client) {
-    vtGateConnection = new VTGateConnection(client);
+    vtGateConnection = new VTGateConnection(client, -1);
   }
 
   /**

--- a/java/client/src/main/java/io/vitess/client/VTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateConnection.java
@@ -23,6 +23,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.vitess.client.cursor.Cursor;
 import io.vitess.client.cursor.CursorWithError;
@@ -49,7 +50,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -69,9 +72,18 @@ import javax.annotation.Nullable;
  * VTGateBlockingConnection} if you want synchronous calls.</p>
  */
 public class VTGateConnection implements Closeable {
-  private static final Logger LOG = LoggerFactory.getLogger(VTGateConnection.class);
-  private static final ExecutorService es = Executors.newCachedThreadPool();
+  private static final ExecutorService QUERY_LOGGING_EXECUTOR = new ThreadPoolExecutor(2, 2,
+          Long.MAX_VALUE,
+          TimeUnit.DAYS,
+          new LinkedBlockingQueue<>(50),
+          new ThreadFactoryBuilder()
+                  .setNameFormat("vitess-slow-query-logger-%d")
+                  .setDaemon(false)
+                  .build(),
+          new ThreadPoolExecutor.DiscardPolicy()
+  );
   private final RpcClient client;
+  private final long slowQueryThreshold;
 
   /**
    * Creates a VTGate connection with no specific parameters.
@@ -81,8 +93,9 @@ public class VTGateConnection implements Closeable {
    *
    * @param client RPC connection
    */
-  public VTGateConnection(RpcClient client) {
+  public VTGateConnection(RpcClient client, long slowQueryThreshold) {
     this.client = checkNotNull(client);
+    this.slowQueryThreshold = slowQueryThreshold;
   }
 
   /**
@@ -119,23 +132,30 @@ public class VTGateConnection implements Closeable {
                 }
               }, directExecutor()));
       vtSession.setLastCall(call);
-      call.addListener(new SlowQueryLogger(start, query), es);
+
+      if (slowQueryThreshold != -1) {
+        call.addListener(new SlowQueryLogger(start, slowQueryThreshold, query),
+                QUERY_LOGGING_EXECUTOR);
+      }
       return call;
     }
   }
 
   private static class SlowQueryLogger implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(VTGateConnection.class);
     private final long startTime;
+    private final long slowQueryCutoff;
     private final String query;
 
-    public SlowQueryLogger(long startTime, String query) {
+    public SlowQueryLogger(long startTime, long slowQueryCutOff, String query) {
       this.startTime = startTime;
+      this.slowQueryCutoff = slowQueryCutOff;
       this.query = query;
     }
 
     @Override public void run() {
       long duration = System.currentTimeMillis() - startTime;
-      if (duration > 100) {
+      if (slowQueryCutoff != -1 && duration > slowQueryCutoff) {
         LOG.info("Query {} took {} ms", query, duration);
       }
     }
@@ -213,9 +233,13 @@ public class VTGateConnection implements Closeable {
                 }
               }, directExecutor()));
       vtSession.setLastCall(call);
-      call.addListener(new SlowQueryLogger(start,
-                                           queryList.stream()
-                                           .findFirst().orElse("empty batch")), es);
+      if (slowQueryThreshold != -1) {
+        call.addListener(new SlowQueryLogger(start,
+                        slowQueryThreshold,
+                        queryList.stream()
+                                .findFirst().orElse("empty batch")),
+                        QUERY_LOGGING_EXECUTOR);
+      }
       return call;
     }
   }
@@ -271,6 +295,7 @@ public class VTGateConnection implements Closeable {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
 
+    // Do I need to log split queries??
     return new SQLFuture<>(
         transformAsync(client.splitQuery(ctx, requestBuilder.build()),
             new AsyncFunction<SplitQueryResponse, List<SplitQueryResponse.Part>>() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -235,6 +235,11 @@ public class ConnectionProperties {
           + "commit/rollback. Query timeout can be overridden by explicitly calling "
           + "setQueryTimeout", Constants.DEFAULT_TIMEOUT);
 
+  private LongConnectionProperty slowQueryLoggingThreshold =
+          new LongConnectionProperty("slowQueryLoggingThreshold",
+          "The threshold in millis, to log queries that exceed it. Set to -1 to disable.",
+          Constants.DEFAULT_SLOW_QUERY_LOGGING_THRESHOLD_MILLIS);
+
   // Caching of some hot properties to avoid casting over and over
   private Topodata.TabletType tabletTypeCache;
   private Query.ExecuteOptions.IncludedFields includedFieldsCache;
@@ -586,6 +591,14 @@ public class ConnectionProperties {
 
   public void setTimeout(long timeout) {
     this.timeout.setValue(timeout);
+  }
+
+  public long getSlowQueryLoggingThreshold() {
+    return slowQueryLoggingThreshold.getValueAsLong();
+  }
+
+  public void setSlowQueryLoggingThreshold(long slowQueryLoggingThreshold) {
+    this.slowQueryLoggingThreshold.setValue(slowQueryLoggingThreshold);
   }
 
   public String getTarget() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -235,9 +235,10 @@ public class ConnectionProperties {
           + "commit/rollback. Query timeout can be overridden by explicitly calling "
           + "setQueryTimeout", Constants.DEFAULT_TIMEOUT);
 
-  private LongConnectionProperty slowQueryLoggingThreshold =
-          new LongConnectionProperty("slowQueryLoggingThreshold",
-          "The threshold in millis, to log queries that exceed it. Set to -1 to disable.",
+  private LongConnectionProperty slowQueryLoggingThresholdMillis =
+          new LongConnectionProperty("slowQueryLoggingThresholdMillis",
+          "The threshold in millis, to log queries that exceed it."
+                   + " Set to -1 to disable. Defaults to -1.",
           Constants.DEFAULT_SLOW_QUERY_LOGGING_THRESHOLD_MILLIS);
 
   // Caching of some hot properties to avoid casting over and over
@@ -593,12 +594,12 @@ public class ConnectionProperties {
     this.timeout.setValue(timeout);
   }
 
-  public long getSlowQueryLoggingThreshold() {
-    return slowQueryLoggingThreshold.getValueAsLong();
+  public long getSlowQueryLoggingThresholdMillis() {
+    return slowQueryLoggingThresholdMillis.getValueAsLong();
   }
 
-  public void setSlowQueryLoggingThreshold(long slowQueryLoggingThreshold) {
-    this.slowQueryLoggingThreshold.setValue(slowQueryLoggingThreshold);
+  public void setSlowQueryLoggingThresholdMillis(long slowQueryLoggingThresholdMillis) {
+    this.slowQueryLoggingThresholdMillis.setValue(slowQueryLoggingThresholdMillis);
   }
 
   public String getTarget() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -224,10 +224,11 @@ public class VitessVTGateManager {
           .trustAlias(trustAlias);
 
       return new RefreshableVTGateConnection(new GrpcClientFactory(channelProvider, errorHandler)
-          .createTls(context, hostInfo.toString(), tlsOptions), keyStorePath, trustStorePath);
+          .createTls(context, hostInfo.toString(), tlsOptions), keyStorePath, trustStorePath,
+              connection.getSlowQueryLoggingThreshold());
     } else {
       return new VTGateConnection(new GrpcClientFactory(channelProvider, errorHandler)
-          .create(context, hostInfo.toString()));
+          .create(context, hostInfo.toString()), connection.getSlowQueryLoggingThreshold());
     }
   }
 

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -225,10 +225,10 @@ public class VitessVTGateManager {
 
       return new RefreshableVTGateConnection(new GrpcClientFactory(channelProvider, errorHandler)
           .createTls(context, hostInfo.toString(), tlsOptions), keyStorePath, trustStorePath,
-              connection.getSlowQueryLoggingThreshold());
+              connection.getSlowQueryLoggingThresholdMillis());
     } else {
       return new VTGateConnection(new GrpcClientFactory(channelProvider, errorHandler)
-          .create(context, hostInfo.toString()), connection.getSlowQueryLoggingThreshold());
+          .create(context, hostInfo.toString()), connection.getSlowQueryLoggingThresholdMillis());
     }
   }
 

--- a/java/jdbc/src/main/java/io/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/io/vitess/util/Constants.java
@@ -45,7 +45,7 @@ public class Constants {
   //Default Timeout in milliseconds
   public static final int DEFAULT_TIMEOUT = 30000;
   //Default slow query logging threshold in milliseconds
-  public static final long DEFAULT_SLOW_QUERY_LOGGING_THRESHOLD_MILLIS = 5000;
+  public static final long DEFAULT_SLOW_QUERY_LOGGING_THRESHOLD_MILLIS = -1;
   public static final String VITESS_KEYSPACE = "Keyspace name in Vitess Server";
   public static final Constants.QueryExecuteType DEFAULT_EXECUTE_TYPE = QueryExecuteType.SIMPLE;
   public static final String EXECUTE_TYPE_DESC = "Query execution type: simple or stream \n";

--- a/java/jdbc/src/main/java/io/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/io/vitess/util/Constants.java
@@ -42,8 +42,10 @@ public class Constants {
   public static final int DRIVER_MAJOR_VERSION = 2;
   public static final int DRIVER_MINOR_VERSION = 2;
   public static final int MAX_BUFFER_SIZE = 65535;
-  //Default Timeout in miliseconds
+  //Default Timeout in milliseconds
   public static final int DEFAULT_TIMEOUT = 30000;
+  //Default slow query logging threshold in milliseconds
+  public static final long DEFAULT_SLOW_QUERY_LOGGING_THRESHOLD_MILLIS = 5000;
   public static final String VITESS_KEYSPACE = "Keyspace name in Vitess Server";
   public static final Constants.QueryExecuteType DEFAULT_EXECUTE_TYPE = QueryExecuteType.SIMPLE;
   public static final String EXECUTE_TYPE_DESC = "Query execution type: simple or stream \n";

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -43,7 +43,7 @@ import org.mockito.Mockito;
 
 public class ConnectionPropertiesTest {
 
-  private static final int NUM_PROPS = 41;
+  private static final int NUM_PROPS = 42;
 
   @Test
   public void testReflection() throws Exception {
@@ -174,8 +174,8 @@ public class ConnectionPropertiesTest {
     assertEquals("grpcRetriesInitialBackoffMillis", infos[9].name);
     assertEquals("grpcRetriesMaxBackoffMillis", infos[10].name);
     assertEquals(Constants.Property.INCLUDED_FIELDS, infos[11].name);
-    assertEquals(Constants.Property.TABLET_TYPE, infos[23].name);
-    assertEquals(Constants.Property.TWOPC_ENABLED, infos[31].name);
+    assertEquals(Constants.Property.TABLET_TYPE, infos[24].name);
+    assertEquals(Constants.Property.TWOPC_ENABLED, infos[32].name);
   }
 
   @Test

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -21,17 +21,15 @@ import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConnection;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.proto.Vtrpc;
-
 import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * Created by naveen.nahata on 29/02/16.
@@ -43,7 +41,7 @@ public class VitessVTGateManagerTest {
     Context ctx = Context.getDefault().withDeadlineAfter(Duration.millis(500))
         .withCallerId(callerId);
     RpcClient client = new GrpcClientFactory().create(ctx, "host:80");
-    return new VTGateConnection(client);
+    return new VTGateConnection(client, -1);
   }
 
   @Test


### PR DESCRIPTION
A little messy, there wasn't a great way to pass the threshold into the `VtGateConnection` and I couldn't pass the `VitessConnection` in because the jdbc module depends on the client module. Happy to move things around and not sure if we want to upstream this or not.

https://git.hubteam.com/HubSpot/sre-team/issues/99