### PR TITLE
Upgrade grpc to 1.20.0

### DIFF
--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -49,16 +49,6 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <version>4.1.30.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-      <version>4.1.30.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
     </dependency>
     <dependency>

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -58,7 +58,7 @@ public class GrpcClientFactory implements RpcClientFactory {
   private NettyChannelBuilderProvider nettyChannelBuilderProvider;
   private ErrorHandler errorHandler;
   private CallCredentials callCredentials;
-  private LoadBalancer.Factory loadBalancerFactory;
+  private String defaultLoadBalancingPolicy;
   private NameResolver.Factory nameResolverFactory;
 
   public GrpcClientFactory() {
@@ -81,8 +81,8 @@ public class GrpcClientFactory implements RpcClientFactory {
     return this;
   }
 
-  public GrpcClientFactory setLoadBalancerFactory(LoadBalancer.Factory value) {
-    loadBalancerFactory = value;
+  public GrpcClientFactory setDefaultLoadBalancingPolicy(String value) {
+    defaultLoadBalancingPolicy = value;
     return this;
   }
 
@@ -102,8 +102,8 @@ public class GrpcClientFactory implements RpcClientFactory {
   @Override
   public RpcClient create(Context ctx, String target) {
     NettyChannelBuilder channel = channelBuilder(target).negotiationType(NegotiationType.PLAINTEXT);
-    if (loadBalancerFactory != null) {
-      channel.loadBalancerFactory(loadBalancerFactory);
+    if (defaultLoadBalancingPolicy != null) {
+      channel.defaultLoadBalancingPolicy(defaultLoadBalancingPolicy);
     }
     if (nameResolverFactory != null) {
       channel.nameResolverFactory(nameResolverFactory);

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/StaticAuthCredentials.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/StaticAuthCredentials.java
@@ -1,9 +1,7 @@
 package io.vitess.client.grpc;
 
-import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.util.Objects;
@@ -12,7 +10,7 @@ import java.util.concurrent.Executor;
 /**
  * {@link CallCredentials} that applies plain username and password.
  */
-public class StaticAuthCredentials implements CallCredentials {
+public class StaticAuthCredentials extends CallCredentials {
 
   private static final Metadata.Key<String> USERNAME =
       Metadata.Key.of("username", Metadata.ASCII_STRING_MARSHALLER);
@@ -28,9 +26,9 @@ public class StaticAuthCredentials implements CallCredentials {
   }
 
   @Override
-  public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
-      Executor executor, MetadataApplier applier) {
-    executor.execute(() -> {
+  public void applyRequestMetadata(
+      RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
+    appExecutor.execute(() -> {
       try {
         Metadata headers = new Metadata();
         headers.put(USERNAME, username);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,11 +67,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
-    <grpc.version>1.16.0</grpc.version>
+    <grpc.version>1.20.0</grpc.version>
     <!-- NOTE Netty handler and boring SSL must be kept compatible with grpc
       https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.handler.version>4.1.30.Final</netty.handler.version>
-    <tcnative.boring.ssl.version>2.0.17.Final</tcnative.boring.ssl.version>
+    <netty.handler.version>4.1.34.Final</netty.handler.version>
+    <tcnative.boring.ssl.version>2.0.22.Final</tcnative.boring.ssl.version>
 
     <protobuf.java.version>3.6.1</protobuf.java.version>
     <protobuf.protoc.version>3.6.1</protobuf.protoc.version>


### PR DESCRIPTION
This upgrades gRPC from 1.60.0 to 1.20.0. We're already running vitess-jdbc against these dep versions internally so I wouldn't expect this to break anything

@acharis @pH14  @achikodi @olyazavr