### PR TITLE
Explicitly set NioSocketChannel

### DIFF
--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
@@ -1,9 +1,9 @@
 package io.vitess.client.grpc.netty;
 
 import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.vitess.client.grpc.RetryingInterceptor;
 import io.vitess.client.grpc.RetryingInterceptorConfig;

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
@@ -1,6 +1,7 @@
 package io.vitess.client.grpc.netty;
 
 import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -22,6 +23,7 @@ public class DefaultChannelBuilderProvider implements NettyChannelBuilderProvide
   @Override
   public NettyChannelBuilder getChannelBuilder(String target) {
     return NettyChannelBuilder.forTarget(target)
+        .setChannel(NioSocketChannel.class)
         .eventLoopGroup(ELG)
         .maxInboundMessageSize(16777216)
         .intercept(new RetryingInterceptor(config));

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
@@ -23,7 +23,7 @@ public class DefaultChannelBuilderProvider implements NettyChannelBuilderProvide
   @Override
   public NettyChannelBuilder getChannelBuilder(String target) {
     return NettyChannelBuilder.forTarget(target)
-        .setChannel(NioSocketChannel.class)
+        .channelType(NioSocketChannel.class)
         .eventLoopGroup(ELG)
         .maxInboundMessageSize(16777216)
         .intercept(new RetryingInterceptor(config));


### PR DESCRIPTION
Due to a grpc upgrade, the default will change from nio to epoll. This hardcodes vitess to stuck with nio for the time being.

Note that I'm not entirely certain if this is the proper class. The grpc-netty docs imply it is, though.