### PR TITLE
ignore legacy code ok, will be ok if non-legacy is ok

### DIFF
--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/error/DefaultErrorHandler.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/error/DefaultErrorHandler.java
@@ -44,8 +44,6 @@ public class DefaultErrorHandler implements ErrorHandler {
     }
 
     switch (error.getLegacyCode()) {
-      case SUCCESS_LEGACY:
-        return null;
       case BAD_INPUT_LEGACY:
         return new SQLSyntaxErrorException(error.toString(), sqlState, errno);
       case DEADLINE_EXCEEDED_LEGACY:


### PR DESCRIPTION
Vitess switched over error codes from "legacy" error codes to non-legacy about 5 years ago, and we didn't really make the migration even though it was available for a long time ([see here](https://github.com/vitessio/vitess/pull/8456)). Now as we upgrade to latest, however, they finally removed the legacy error codes, which our `DefaultErrorHandling` code relies on. 

The only real change here is that the `legacyCode` will always be `0`, which currently indicates to us that there is no error.

However, we already check if the `errorCode` (non-legacy) is `0`, in which case it is truly not an error. We can safely remove this `legacyCode == 0` check so if there's an error that isn't one of the ones enumerated, it can fall through to the `SQLNonTransientException` default.

The others listed are the same, just legacy and not