### PR TITLE
port over additional transaction isolation field to proto

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
@@ -306,6 +306,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
     checkOpen();
     switch (this.vtSession.getTransactionIsolation()) {
       case DEFAULT:
+      case AUTOCOMMIT:
         return this.getMetaData().getDefaultTransactionIsolation();
       case READ_COMMITTED:
         return Connection.TRANSACTION_READ_COMMITTED;

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -292,6 +292,10 @@ message ExecuteOptions {
     // This is not an "official" transaction level but it will do a
     // START TRANSACTION WITH CONSISTENT SNAPSHOT, READ ONLY
     CONSISTENT_SNAPSHOT_READ_ONLY = 5;
+    
+    // This not an "official" transaction level, it will send queries to mysql
+    // without wrapping them in a transaction
+    AUTOCOMMIT = 6;
   }
 
   TransactionIsolation transaction_isolation = 9;


### PR DESCRIPTION
This was added many years ago (https://github.com/vitessio/vitess/pull/4739) but we never fast-forwarded our branch. This currently breaks parsing out v13 responses. We should really fast-forward the branch and do a slow calculated roll-out, but for now to further our server upgrade efforts, adding this field in will stop the breakage