### PR TITLE
Backport rpc errors

### DIFF
--- a/proto/vtrpc.proto
+++ b/proto/vtrpc.proto
@@ -169,6 +169,12 @@ enum Code {
 
   // DATA_LOSS indicates unrecoverable data loss or corruption.
   DATA_LOSS = 15;
+
+  // CLUSTER_EVENT indicates that a cluster operation might be in effect
+  CLUSTER_EVENT = 17;
+
+  // Topo server connection is read-only
+  READ_ONLY = 18;
 }
 
 // LegacyErrorCode is the enum values for Errors. This type is deprecated.


### PR DESCRIPTION
These rpc errors are used by Vitess14 and are missing from our fork. 
The end result is that some errors returned from the vtgate are interpreted as Unrecognized errors and not as CLUSTER_EVENT, READ_ONLY errors by the java client

Error prior to back port
```
	at io.vitess.jdbc.VitessConnection$1.run(VitessConnection.java:537)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.sql.SQLNonTransientException: Vitess vtgate error: message: "vttablet: rpc error: code = Code(17) desc = operation not allowed in state NOT_SERVING"
code: UNKNOWN_ENUM_VALUE_Code_17
```

Error with back port
```
	... 3 common frames omitted
Caused by: java.util.concurrent.ExecutionException: java.sql.SQLNonTransientException: Vitess vtgate error: message: "vttablet: rpc error: code = Code(17) desc = operation not allowed in state NOT_SERVING"
code: CLUSTER_EVENT
```