### PR TITLE
add forwards compability with primary type rename

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
@@ -178,6 +178,12 @@ public class VitessJDBCUrl {
       info.setProperty(Constants.Property.TABLET_TYPE, oldTabletType);
     }
 
+    // for forwards compatibility, remove when done with migration to primary
+    if ("primary".equals(tabletType) || "primary".equals(oldTabletType)) {
+      info.setProperty(Constants.Property.TABLET_TYPE, "master");
+      info.setProperty(Constants.Property.OLD_TABLET_TYPE, "master");
+    }
+
     this.info = info;
   }
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -183,6 +183,26 @@ public class VitessVTGateManagerTest {
     VitessVTGateManager.close();
   }
 
+  @Test
+  public void testUsingNewNamingIsForwardsCompatible() throws Exception {
+    VitessVTGateManager.close();
+    String keystoreName1 = "primary";
+    String truststoreName1 = "truststore1";
+    VitessConnection connection1 = makeConnectionForKeystore("primary", keystoreName1, truststoreName1);
+
+    GrpcClientFactory mockedGrpcClientFactory = mock(GrpcClientFactory.class);
+    RpcClient mockedRpcClient = mock(RpcClient.class);
+    whenNew(GrpcClientFactory.class).withAnyArguments().thenReturn(mockedGrpcClientFactory);
+    when(mockedGrpcClientFactory.createTls(any(Context.class), anyString(), any(TlsOptions.class))).thenReturn(mockedRpcClient);
+
+    VitessVTGateManager.VTGateConnections vtGateConnections1 =
+        new VitessVTGateManager.VTGateConnections(
+            connection1);
+    String connectionKeystoreName1 = getKeystoreName(vtGateConnections1);
+    Assert.assertEquals(keystoreName1, connectionKeystoreName1);
+    VitessVTGateManager.close();
+  }
+
   private static VitessConnection makeConnectionForKeystore(String tabletType, String keystoreName, String truststoreName) throws SQLException {
     Properties info = new Properties();
     info.setProperty(Constants.Property.USERNAME, "user");


### PR DESCRIPTION
We want to upgrade our client to be the latest, but this requires changes on our side as well, to rename master to primary. To make that seamless, have the new client accept either one for now