### PR TITLE
fetch-depth 0

### DIFF
--- a/.github/workflows/sync_vitessio.yml
+++ b/.github/workflows/sync_vitessio.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main-2025-q2
+          fetch-depth: 0
           persist-credentials: 'false'
 
       - name: Set up git user


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

We are seeing [many merge conflicts](https://github.com/HubSpot/vitess/actions/runs/16275145206/job/45952116431) with the sync_vitessio workflow when we only expect to see one (gitignore).

HubGPT recommends adding  `fetch-depth: 0` since github actions defaults to a fetch-depth of 1. Can't guarantee that this will fix it, but it is currently our best bet with everything else being equal. fetch-depth defaults to 0 in the git CLI, which makes sense because we only see one merge conflict when running the sync commands locally.
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
