### PR TITLE
Use PAT for sync workflow

### DIFF
--- a/.github/workflows/sync_vitessio.yml
+++ b/.github/workflows/sync_vitessio.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: main-2025-q2
           fetch-depth: 0
+          token: ${{ secrets.VITESS_SYNC_PAT }}
           persist-credentials: true # keep creds for push
 
       - name: Set up git user


### PR DESCRIPTION
## Description

Allow the sync workflow to overwrite other workflows by using a PAT (saved as a repo secret) instead of the default actions token.

