### PR TITLE
External Auto Inc ID Service (VTickets)

### DIFF
--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/thirdparty"
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
@@ -107,6 +108,8 @@ vttablet \
 
 func init() {
 	srvTopoCounts = stats.NewCountersWithSingleLabel("TabletSrvTopo", "Resilient srvtopo server operations", "type")
+	// Initalize any third party implementations for vitess
+	thirdparty.InitializeThirdParty(Main)
 }
 
 func run(cmd *cobra.Command, args []string) error {

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -350,7 +350,7 @@ func (ic *InsertCommon) processGenerateFromSelect(
 	vcursor VCursor,
 	loggingPrimitive Primitive,
 	rows []sqltypes.Row,
-) (insertID int64, err error) {
+) (firstInsertID int64, err error) {
 	if ic.Generate == nil {
 		return 0, nil
 	}
@@ -371,25 +371,55 @@ func (ic *InsertCommon) processGenerateFromSelect(
 		return 0, nil
 	}
 
-	insertID, err = ic.execGenerate(ctx, vcursor, loggingPrimitive, count)
+	var insertIDs []sqltypes.Value = make([]sqltypes.Value, 0)
+	firstInsertID, insertIDs, err = ic.execGenerate(ctx, vcursor, loggingPrimitive, count)
 	if err != nil {
 		return 0, err
 	}
 
-	used := insertID
+	used := firstInsertID
+	insertIDsIndex := 0
 	for idx, val := range rows {
 		if genColPresent {
 			if shouldGenerate(val[offset], evalengine.ParseSQLMode(vcursor.SQLMode())) {
-				val[offset] = sqltypes.NewInt64(used)
+				// if we have insertIDs to use, use them, otherwise generate a +1 new id off the last id we used
+				// note: vitess sequences only returns only a single id value and then increments that id for each id field
+				// note: external auto inc service return a list of all the id values we need for each id field (this supports skipped id values)
+				if insertIDsIndex < len(insertIDs) {
+					val[offset] = insertIDs[insertIDsIndex]
+					// store the current id value in the used variable
+					used, err = insertIDs[insertIDsIndex].ToCastInt64()
+					if err != nil {
+						return 0, err
+					}
+					insertIDsIndex++
+				} else {
+					val[offset] = sqltypes.NewInt64(used)
+				}
+				// increment the used variable by 1 (in case we don't have any insertIDs to use on the next iteration)
 				used++
 			}
 		} else {
-			rows[idx] = append(val, sqltypes.NewInt64(used))
+			// if we have insertIDs to use, use them, otherwise generate a +1 new id off the last id we used
+			// note: vitess sequences only returns only a single id value and then increments that id for each id field
+			// note: external auto inc service return a list of all the id values we need for each id field (this supports skipped id values)
+			if insertIDsIndex < len(insertIDs) {
+				rows[idx] = append(val, insertIDs[insertIDsIndex])
+				// store the current id value in the used variable
+				used, err = insertIDs[insertIDsIndex].ToCastInt64()
+				if err != nil {
+					return 0, err
+				}
+				insertIDsIndex++
+			} else {
+				rows[idx] = append(val, sqltypes.NewInt64(used))
+			}
+			// increment the used variable by 1 (in case we don't have any insertIDs to use on the next iteration)
 			used++
 		}
 	}
 
-	return insertID, nil
+	return firstInsertID, nil
 }
 
 // processGenerateFromValues generates new values using a sequence if necessary.
@@ -400,7 +430,7 @@ func (ic *InsertCommon) processGenerateFromValues(
 	vcursor VCursor,
 	loggingPrimitive Primitive,
 	bindVars map[string]*querypb.BindVariable,
-) (insertID int64, err error) {
+) (firstInsertID int64, err error) {
 	if ic.Generate == nil {
 		return 0, nil
 	}
@@ -421,43 +451,67 @@ func (ic *InsertCommon) processGenerateFromValues(
 	}
 
 	// If generation is needed, generate the requested number of values (as one call).
+	var insertIDs []sqltypes.Value = make([]sqltypes.Value, 0)
 	if count != 0 {
-		insertID, err = ic.execGenerate(ctx, vcursor, loggingPrimitive, count)
+		firstInsertID, insertIDs, err = ic.execGenerate(ctx, vcursor, loggingPrimitive, count)
 		if err != nil {
 			return 0, err
 		}
 	}
 
 	// Fill the holes where no value was supplied.
-	cur := insertID
+	cur := firstInsertID
+	insertIDsIndex := 0
 	for i, v := range values {
 		if shouldGenerate(v, evalengine.ParseSQLMode(vcursor.SQLMode())) {
-			bindVars[SeqVarName+strconv.Itoa(i)] = sqltypes.Int64BindVariable(cur)
+			// if we have snsertIDs to use, use them, otherwise generate a +1 new id off the last id we used
+			// note: vitess sequences only returns only a single id value and then increments that id for each id field
+			// note: external auto inc service return a list of all the id values we need for each id field (this support skipped id values)
+			if insertIDsIndex < len(insertIDs) {
+				bindVars[SeqVarName+strconv.Itoa(i)] = sqltypes.ValueBindVariable(insertIDs[insertIDsIndex])
+				// store the current id value in the cur variable
+				cur, err = insertIDs[insertIDsIndex].ToCastInt64()
+				if err != nil {
+					return 0, err
+				}
+				insertIDsIndex++
+			} else {
+				bindVars[SeqVarName+strconv.Itoa(i)] = sqltypes.Int64BindVariable(cur)
+			}
+			// increment the cur variable by 1 (in case we don't have any insertIDs to use on the next iteration)
 			cur++
 		} else {
 			bindVars[SeqVarName+strconv.Itoa(i)] = sqltypes.ValueBindVariable(v)
 		}
 	}
-	return insertID, nil
+	return firstInsertID, nil
 }
 
-func (ic *InsertCommon) execGenerate(ctx context.Context, vcursor VCursor, loggingPrimitive Primitive, count int64) (int64, error) {
+// HubSpot Fix: instead of returning just the first insert id, return both the first insert id and the list of all the specific id values to use (for instances where ID values are not in order)
+func (ic *InsertCommon) execGenerate(ctx context.Context, vcursor VCursor, loggingPrimitive Primitive, count int64) (int64, []sqltypes.Value, error) {
 	// If generation is needed, generate the requested number of values (as one call).
 	rss, _, err := vcursor.ResolveDestinations(ctx, ic.Generate.Keyspace.Name, nil, []key.ShardDestination{key.DestinationAnyShard{}})
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if len(rss) != 1 {
-		return 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "auto sequence generation can happen through single shard only, it is getting routed to %d shards", len(rss))
+		return 0, nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "auto sequence generation can happen through single shard only, it is getting routed to %d shards", len(rss))
 	}
 	bindVars := map[string]*querypb.BindVariable{nextValBV: sqltypes.Int64BindVariable(count)}
 	qr, err := vcursor.ExecuteStandalone(ctx, loggingPrimitive, ic.Generate.Query, bindVars, rss[0], ic.FetchLastInsertID)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
+	}
+
+	// HubSpot fix: return all the row values we need to generate for each id field
+	insertIDs := make([]sqltypes.Value, len(qr.Rows))
+	for i, row := range qr.Rows {
+		insertIDs[i] = row[0]
 	}
 	// If no rows are returned, it's an internal error, and the code
 	// must panic, which will be caught and reported.
-	return qr.Rows[0][0].ToCastInt64()
+	firstInsertID, err := qr.Rows[0][0].ToCastInt64()
+	return firstInsertID, insertIDs, nil
 }
 
 // shouldGenerate determines if a sequence value should be generated for a given value

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/ptr"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -928,7 +929,25 @@ func resolveAutoIncrement(source *vschemapb.SrvVSchema, vschema *VSchema, parser
 			if t == nil || table.AutoIncrement == nil {
 				continue
 			}
-			seqks, seqtab, err := parser.ParseTable(table.AutoIncrement.Sequence)
+			var seqks, seqtab string
+			var err error
+			// For HubSpot VTickets, we want to hack alongside of sequences.  We'll inject enough info into the vtgate
+			// for the underlying sequence auto-incrementer parser/rewriter to work in the query planner
+			// Then in the vttablet we'll skip over Sequences and use VTickets to get the next ID value
+			if table.AutoIncrement.UseVTickets {
+				log.Infof("VTICKETS: VTickets is Enabled for table %s", tname)
+				// If VTicketSourceKeyspace is set then we are using a remote VTickets Source Table, so lets use both those values...
+				if table.AutoIncrement.VTicketSourceKeyspace != "" {
+					seqks = table.AutoIncrement.VTicketSourceKeyspace
+					seqtab = table.AutoIncrement.VTicketSourceTable
+				} else {
+					// Otherwise, we are using a local VTickets Source Table, so lets use the table name (and default to this keyspace)
+					seqks, seqtab = ksname, tname
+				}
+			} else {
+				// The original Vitess Sequence behavior
+				seqks, seqtab, err = parser.ParseTable(table.AutoIncrement.Sequence)
+			}
 			var seq *BaseTable
 			if err == nil {
 				// Ensure that sequence tables also obey routing rules.

--- a/go/vt/vttablet/tabletserver/external_autoinc_id_service.go
+++ b/go/vt/vttablet/tabletserver/external_autoinc_id_service.go
@@ -1,0 +1,51 @@
+package tabletserver
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+)
+
+type ExternalAutoIncIDService interface {
+	BindTopoServer(topoServer *topo.Server)
+	BindSchemaEngine(schemaEngine *schema.Engine)
+	BindIsServing(isServingFunc func() bool)
+	InitializeExternalAutoIncIDService(target *querypb.Target)
+	IsExternalAutoIncIDEnabled(keyspace string, tableName string) bool
+	GetNextIDs(tableName string, count int64) (*sqltypes.Result, error)
+}
+
+type DisabledExternalAutoIncIDService struct{}
+
+func (d *DisabledExternalAutoIncIDService) BindTopoServer(topoServer *topo.Server) {
+	// no-op / do nothing
+}
+
+func (d *DisabledExternalAutoIncIDService) BindSchemaEngine(schemaEngine *schema.Engine) {
+	//  no-op / do nothing
+}
+
+func (d *DisabledExternalAutoIncIDService) BindIsServing(isServingFunc func() bool) {
+	// no-op / do nothing
+}
+
+func (d *DisabledExternalAutoIncIDService) InitializeExternalAutoIncIDService(target *querypb.Target) {
+	//  no-op / do nothing
+}
+
+func (d *DisabledExternalAutoIncIDService) IsExternalAutoIncIDEnabled(keyspace string, tableName string) bool {
+	return false
+}
+
+func (d *DisabledExternalAutoIncIDService) GetNextIDs(tableName string, count int64) (*sqltypes.Result, error) {
+	return nil, fmt.Errorf("exteranl auto-increment ID service is not implemented and disabled")
+}
+
+var externalAutoIncIDService ExternalAutoIncIDService = &DisabledExternalAutoIncIDService{}
+
+func RegisterExternalAutoIncIDService(thirdPartyExternalAutoIncIDService ExternalAutoIncIDService) {
+	externalAutoIncIDService = thirdPartyExternalAutoIncIDService
+}

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -58,7 +58,10 @@ func analyzeSelect(env *vtenv.Environment, sel *sqlparser.Select, tables map[str
 
 	// Check if it's a NEXT VALUE statement.
 	if nextVal, ok := sel.GetColumns()[0].(*sqlparser.Nextval); ok {
-		if plan.Table == nil || plan.Table.Type != schema.Sequence {
+		// !!!!! HubSpot HACK !!!!! for != (not equal to) vs > (greater than) for VTickets
+		// plan.Table.Type is 0 (NoType) for VTickets and 1 for Sequence
+		// This allows for VTickets to create a PlanNextval plan for VTickets and *shouldn't break* because NEXTVAL is only used for sequences...
+		if plan.Table == nil || plan.Table.Type > schema.Sequence {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%s is not a sequence", sqlparser.ToString(sel.From))
 		}
 		plan.PlanID = PlanNextval

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -673,6 +673,12 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid increment for sequence %s: %s", tableName, v.String())
 	}
 
+	// If external auto-increment ID service is enabled, then use it to get the next ID(s) and short circuit the normal sequence behavior
+	if externalAutoIncIDService.IsExternalAutoIncIDEnabled(qre.tsv.sm.target.Keyspace, qre.plan.Table.Name.String()) {
+		return externalAutoIncIDService.GetNextIDs(qre.plan.Table.Name.String(), inc)
+	}
+
+	// Otherwise, use the normal sequence behavior
 	t := qre.plan.Table
 	t.SequenceInfo.Lock()
 	defer t.SequenceInfo.Unlock()

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -465,6 +465,10 @@ func (sm *stateManager) servePrimary() error {
 	// to ensure that we don't miss any updates from the schema engine.
 	sm.hs.MakePrimary(true)
 	sm.se.MakePrimary(true)
+
+	// Initialize the ExternalAutoIncIDService for this keysapce/shard
+	externalAutoIncIDService.InitializeExternalAutoIncIDService(sm.target)
+
 	sm.rt.MakePrimary()
 	sm.tracker.Open()
 	// We instantly kill all stateful queries to allow for

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -258,6 +258,11 @@ func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, c
 	tsv.registerThrottlerHandlers()
 	tsv.registerDebugEnvHandler()
 
+	// bind the topo server, schema engine, and is serving function to the external auto-increment ID service
+	externalAutoIncIDService.BindTopoServer(tsv.topoServer)
+	externalAutoIncIDService.BindSchemaEngine(tsv.se)
+	externalAutoIncIDService.BindIsServing(tsv.IsServing)
+
 	return tsv
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
- This is the working sequence hack/override for getting an External Auto Inc ID Service to inject their own IDs into inserts
- It works by piggybacking off of Vitess Sequence but instead of calling into the "sequence table" to get the next ID(s), it instead grabs IDs from an external service (IE VTickets at HubSpot) and uses that instead
- This implemenation has one HACK and one quasi bug-fix...
    - HACK: In builder.go we let it escape a sequence sanity test for non sequence tables
    - Quasi bug-fix: In insert_common.go, sequences assumes all Ids are in order, but with an external auto-inc service (like vtickets) we skip ranges mid insert
        - This is probably like a 0.5% use case but in the case where we skip IDs mid insert statement, we need to handle that. So instead of assuming we can increment, I updated the code to actually look at all the IDs returned and use them if possibe, if not default to the old algorithm of just auto-incing the last ID seen
- This also gets us 90% of the way there to upstream an external auto inc ID service where in the future we could remove the leg-chopping work on top of sequences and instead make sequences uses this service!


