### PR TITLE
VTorc Cells to Watch

### DIFF
--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -306,9 +306,15 @@ func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, 
 		log.Errorf("Error fetching tablets for keyspace/shard %v/%v: %v", keyspace, shard, err)
 		return
 	}
+	matchedTablets := make([]*topo.TabletInfo, 0, len(tablets))
+	for _, t := range tablets {
+		if shouldWatchTablet(t.Tablet) {
+			matchedTablets = append(matchedTablets, t)
+		}
+	}
 	query := "select alias from vitess_tablet where keyspace = ? and shard = ?"
 	args := sqlutils.Args(keyspace, shard)
-	refreshTablets(tablets, query, args, loader, forceRefresh, tabletsToIgnore)
+	refreshTablets(matchedTablets, query, args, loader, forceRefresh, tabletsToIgnore)
 }
 
 func refreshTablets(tablets []*topo.TabletInfo, query string, args []any, loader func(tabletAlias string), forceRefresh bool, tabletsToIgnore []string) {

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -242,6 +242,7 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 				filteredCells = append(filteredCells, cell)
 			}
 		}
+		log.Infof("refreshTabletsUsing: cellsToWatch=%v knownCells=%v filteredCells=%v", cellsToWatch, cells, filteredCells)
 		cells = filteredCells
 	}
 
@@ -266,9 +267,12 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 			for _, t := range tablets {
 				if shouldWatchTablet(t.Tablet) {
 					matchedTablets = append(matchedTablets, t)
+				} else {
+					log.Infof("refreshTabletsUsing: filtering out tablet %v in cell %v (cellsToWatch=%v)", topoproto.TabletAliasString(t.Tablet.GetAlias()), t.Tablet.GetAlias().GetCell(), cellsToWatch)
 				}
 			}
 		}()
+		log.Infof("refreshTabletsUsing: cell=%v total=%d matched=%d", cell, len(tablets), len(matchedTablets))
 
 		// Refresh the filtered tablets and forget stale tablets.
 		query := "select alias from vitess_tablet where cell = ?"
@@ -283,6 +287,7 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 // for a given shard. This function is meant to be called before or after a cluster-wide operation that we know will
 // change the replication information for the entire cluster drastically enough to warrant a full forceful refresh
 func forceRefreshAllTabletsInShard(ctx context.Context, keyspace, shard string, tabletsToIgnore []string) {
+	log.Infof("forceRefreshAllTabletsInShard: keyspace=%v shard=%v tabletsToIgnore=%v", keyspace, shard, tabletsToIgnore)
 	refreshCtx, refreshCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer refreshCancel()
 	refreshTabletsInKeyspaceShard(refreshCtx, keyspace, shard, func(tabletAlias string) {
@@ -310,8 +315,11 @@ func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, 
 	for _, t := range tablets {
 		if shouldWatchTablet(t.Tablet) {
 			matchedTablets = append(matchedTablets, t)
+		} else {
+			log.Infof("refreshTabletsInKeyspaceShard: filtering out tablet %v in cell %v (cellsToWatch=%v)", topoproto.TabletAliasString(t.Tablet.GetAlias()), t.Tablet.GetAlias().GetCell(), cellsToWatch)
 		}
 	}
+	log.Infof("refreshTabletsInKeyspaceShard: keyspace=%v shard=%v total=%d matched=%d", keyspace, shard, len(tablets), len(matchedTablets))
 	query := "select alias from vitess_tablet where keyspace = ? and shard = ?"
 	args := sqlutils.Args(keyspace, shard)
 	refreshTablets(matchedTablets, query, args, loader, forceRefresh, tabletsToIgnore)

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -242,7 +242,6 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 				filteredCells = append(filteredCells, cell)
 			}
 		}
-		log.Infof("refreshTabletsUsing: cellsToWatch=%v knownCells=%v filteredCells=%v", cellsToWatch, cells, filteredCells)
 		cells = filteredCells
 	}
 
@@ -267,13 +266,9 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 			for _, t := range tablets {
 				if shouldWatchTablet(t.Tablet) {
 					matchedTablets = append(matchedTablets, t)
-				} else {
-					log.Infof("refreshTabletsUsing: filtering out tablet %v in cell %v (cellsToWatch=%v)", topoproto.TabletAliasString(t.Tablet.GetAlias()), t.Tablet.GetAlias().GetCell(), cellsToWatch)
 				}
 			}
 		}()
-		log.Infof("refreshTabletsUsing: cell=%v total=%d matched=%d", cell, len(tablets), len(matchedTablets))
-
 		// Refresh the filtered tablets and forget stale tablets.
 		query := "select alias from vitess_tablet where cell = ?"
 		args := sqlutils.Args(cell)
@@ -287,7 +282,6 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 // for a given shard. This function is meant to be called before or after a cluster-wide operation that we know will
 // change the replication information for the entire cluster drastically enough to warrant a full forceful refresh
 func forceRefreshAllTabletsInShard(ctx context.Context, keyspace, shard string, tabletsToIgnore []string) {
-	log.Infof("forceRefreshAllTabletsInShard: keyspace=%v shard=%v tabletsToIgnore=%v", keyspace, shard, tabletsToIgnore)
 	refreshCtx, refreshCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer refreshCancel()
 	refreshTabletsInKeyspaceShard(refreshCtx, keyspace, shard, func(tabletAlias string) {
@@ -315,11 +309,8 @@ func refreshTabletsInKeyspaceShard(ctx context.Context, keyspace, shard string, 
 	for _, t := range tablets {
 		if shouldWatchTablet(t.Tablet) {
 			matchedTablets = append(matchedTablets, t)
-		} else {
-			log.Infof("refreshTabletsInKeyspaceShard: filtering out tablet %v in cell %v (cellsToWatch=%v)", topoproto.TabletAliasString(t.Tablet.GetAlias()), t.Tablet.GetAlias().GetCell(), cellsToWatch)
 		}
 	}
-	log.Infof("refreshTabletsInKeyspaceShard: keyspace=%v shard=%v total=%d matched=%d", keyspace, shard, len(tablets), len(matchedTablets))
 	query := "select alias from vitess_tablet where keyspace = ? and shard = ?"
 	args := sqlutils.Args(keyspace, shard)
 	refreshTablets(matchedTablets, query, args, loader, forceRefresh, tabletsToIgnore)

--- a/go/vt/vtorc/logic/tablet_discovery.go
+++ b/go/vt/vtorc/logic/tablet_discovery.go
@@ -47,6 +47,7 @@ var (
 	ts               *topo.Server
 	tmc              tmclient.TabletManagerClient
 	clustersToWatch  []string
+	cellsToWatch     []string
 	shutdownWaitTime = 30 * time.Second
 	// shardsToWatch is a map storing the shards for a given keyspace that need to be watched.
 	// We store the key range for all the shards that we want to watch.
@@ -98,6 +99,7 @@ func getTabletsWatchedByShardStats() map[string]int64 {
 // RegisterFlags registers the flags required by VTOrc
 func RegisterFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&clustersToWatch, "clusters_to_watch", clustersToWatch, "Comma-separated list of keyspaces or keyspace/keyranges that this instance will monitor and repair. Defaults to all clusters in the topology. Example: \"ks1,ks2/-80\"")
+	fs.StringSliceVar(&cellsToWatch, "cells_to_watch", cellsToWatch, "Comma-separated list of cells that this instance will monitor and repair. Defaults to all cells in the topology. Example: \"vt_blue,vt_green\"")
 	fs.DurationVar(&shutdownWaitTime, "shutdown_wait_time", shutdownWaitTime, "Maximum time to wait for VTOrc to release all the locks that it is holding before shutting down on SIGTERM")
 }
 
@@ -142,6 +144,9 @@ func initializeShardsToWatch() error {
 
 // shouldWatchTablet checks if the given tablet is part of the watch list.
 func shouldWatchTablet(tablet *topodatapb.Tablet) bool {
+	if len(cellsToWatch) > 0 && !slices.Contains(cellsToWatch, tablet.GetAlias().GetCell()) {
+		return false
+	}
 	// If we are watching all keyspaces, then we want to watch this tablet too.
 	if len(shardsToWatch) == 0 {
 		return true
@@ -228,6 +233,16 @@ func refreshTabletsUsing(ctx context.Context, loader func(tabletAlias string), f
 	cells, err := ts.GetKnownCells(cellsCtx)
 	if err != nil {
 		return err
+	}
+
+	if len(cellsToWatch) > 0 {
+		var filteredCells []string
+		for _, cell := range cells {
+			if slices.Contains(cellsToWatch, cell) {
+				filteredCells = append(filteredCells, cell)
+			}
+		}
+		cells = filteredCells
 	}
 
 	// Get all tablets from all cells.
@@ -386,7 +401,7 @@ func setReplicationSource(ctx context.Context, replica *topodatapb.Tablet, prima
 func shardPrimary(keyspace string, shard string) (primary *topodatapb.Tablet, err error) {
 	query := `SELECT
 		info
-	FROM 
+	FROM
 		vitess_tablet
 	WHERE
 		keyspace = ? AND shard = ?

--- a/go/vt/vtorc/logic/tablet_discovery_test.go
+++ b/go/vt/vtorc/logic/tablet_discovery_test.go
@@ -1024,3 +1024,75 @@ func TestRefreshTabletsUsingCellsToWatch(t *testing.T) {
 	_, err = inst.ReadTablet(topoproto.TabletAliasString(tabCell2.Alias))
 	assert.Error(t, err)
 }
+
+func TestRefreshTabletsInKeyspaceShardCellsToWatch(t *testing.T) {
+	oldTs := ts
+	oldCellsToWatch := cellsToWatch
+	oldClustersToWatch := clustersToWatch
+	oldShardsToWatch := shardsToWatch
+	defer func() {
+		ts = oldTs
+		cellsToWatch = oldCellsToWatch
+		clustersToWatch = oldClustersToWatch
+		shardsToWatch = oldShardsToWatch
+		db.ClearVTOrcDatabase()
+	}()
+
+	cell2 := "zone-2"
+
+	tabCell1 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell1,
+			Uid:  200,
+		},
+		Hostname:      hostname,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Type:          topodatapb.TabletType_REPLICA,
+		MysqlHostname: hostname,
+		MysqlPort:     200,
+	}
+	tabCell2 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell2,
+			Uid:  201,
+		},
+		Hostname:      hostname,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Type:          topodatapb.TabletType_REPLICA,
+		MysqlHostname: hostname,
+		MysqlPort:     201,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ts = memorytopo.NewServer(ctx, cell1, cell2)
+	_, err := ts.GetOrCreateShard(context.Background(), keyspace, shard)
+	require.NoError(t, err)
+
+	err = ts.CreateTablet(context.Background(), tabCell1)
+	require.NoError(t, err)
+	err = ts.CreateTablet(context.Background(), tabCell2)
+	require.NoError(t, err)
+
+	clustersToWatch = nil
+	shardsToWatch = make(map[string][]*topodatapb.KeyRange)
+	cellsToWatch = []string{cell1}
+
+	var discoveredAliases []string
+	refreshTabletsInKeyspaceShard(ctx, keyspace, shard, func(tabletAlias string) {
+		discoveredAliases = append(discoveredAliases, tabletAlias)
+	}, true, nil)
+
+	assert.Contains(t, discoveredAliases, topoproto.TabletAliasString(tabCell1.Alias))
+	assert.NotContains(t, discoveredAliases, topoproto.TabletAliasString(tabCell2.Alias))
+
+	tabletFromDB, err := inst.ReadTablet(topoproto.TabletAliasString(tabCell1.Alias))
+	assert.NoError(t, err)
+	assert.NotNil(t, tabletFromDB)
+
+	_, err = inst.ReadTablet(topoproto.TabletAliasString(tabCell2.Alias))
+	assert.Error(t, err)
+}

--- a/go/vt/vtorc/logic/tablet_discovery_test.go
+++ b/go/vt/vtorc/logic/tablet_discovery_test.go
@@ -107,13 +107,16 @@ var (
 
 func TestShouldWatchTablet(t *testing.T) {
 	oldClustersToWatch := clustersToWatch
+	oldCellsToWatch := cellsToWatch
 	defer func() {
 		clustersToWatch = oldClustersToWatch
+		cellsToWatch = oldCellsToWatch
 		shardsToWatch = nil
 	}()
 
 	testCases := []struct {
 		in                  []string
+		cells               []string
 		tablet              *topodatapb.Tablet
 		expectedShouldWatch bool
 	}{
@@ -213,11 +216,59 @@ func TestShouldWatchTablet(t *testing.T) {
 			},
 			expectedShouldWatch: false,
 		},
+		{
+			cells: nil,
+			tablet: &topodatapb.Tablet{
+				Alias:    &topodatapb.TabletAlias{Cell: "zone-1"},
+				Keyspace: keyspace,
+				Shard:    shard,
+			},
+			expectedShouldWatch: true,
+		},
+		{
+			cells: []string{"zone-1"},
+			tablet: &topodatapb.Tablet{
+				Alias:    &topodatapb.TabletAlias{Cell: "zone-1"},
+				Keyspace: keyspace,
+				Shard:    shard,
+			},
+			expectedShouldWatch: true,
+		},
+		{
+			cells: []string{"zone-2"},
+			tablet: &topodatapb.Tablet{
+				Alias:    &topodatapb.TabletAlias{Cell: "zone-1"},
+				Keyspace: keyspace,
+				Shard:    shard,
+			},
+			expectedShouldWatch: false,
+		},
+		{
+			in:    []string{keyspace},
+			cells: []string{"zone-1"},
+			tablet: &topodatapb.Tablet{
+				Alias:    &topodatapb.TabletAlias{Cell: "zone-1"},
+				Keyspace: keyspace,
+				Shard:    shard,
+			},
+			expectedShouldWatch: true,
+		},
+		{
+			in:    []string{keyspace},
+			cells: []string{"zone-2"},
+			tablet: &topodatapb.Tablet{
+				Alias:    &topodatapb.TabletAlias{Cell: "zone-1"},
+				Keyspace: keyspace,
+				Shard:    shard,
+			},
+			expectedShouldWatch: false,
+		},
 	}
 
 	for _, tt := range testCases {
-		t.Run(fmt.Sprintf("%v-Tablet-%v-%v", strings.Join(tt.in, ","), tt.tablet.GetKeyspace(), tt.tablet.GetShard()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("clusters=%v,cells=%v,Tablet-%v-%v-%v", strings.Join(tt.in, ","), strings.Join(tt.cells, ","), tt.tablet.GetAlias().GetCell(), tt.tablet.GetKeyspace(), tt.tablet.GetShard()), func(t *testing.T) {
 			clustersToWatch = tt.in
+			cellsToWatch = tt.cells
 			err := initializeShardsToWatch()
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedShouldWatch, shouldWatchTablet(tt.tablet))
@@ -899,4 +950,77 @@ func TestGetAllTablets(t *testing.T) {
 			require.Equal(t, t.Name(), tablet.Tablet.GetHostname())
 		}
 	}
+}
+
+func TestRefreshTabletsUsingCellsToWatch(t *testing.T) {
+	oldTs := ts
+	oldCellsToWatch := cellsToWatch
+	oldClustersToWatch := clustersToWatch
+	oldShardsToWatch := shardsToWatch
+	defer func() {
+		ts = oldTs
+		cellsToWatch = oldCellsToWatch
+		clustersToWatch = oldClustersToWatch
+		shardsToWatch = oldShardsToWatch
+		db.ClearVTOrcDatabase()
+	}()
+
+	cell2 := "zone-2"
+
+	tabCell1 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell1,
+			Uid:  200,
+		},
+		Hostname:      hostname,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Type:          topodatapb.TabletType_REPLICA,
+		MysqlHostname: hostname,
+		MysqlPort:     200,
+	}
+	tabCell2 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell2,
+			Uid:  201,
+		},
+		Hostname:      hostname,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Type:          topodatapb.TabletType_REPLICA,
+		MysqlHostname: hostname,
+		MysqlPort:     201,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ts = memorytopo.NewServer(ctx, cell1, cell2)
+	_, err := ts.GetOrCreateShard(context.Background(), keyspace, shard)
+	require.NoError(t, err)
+
+	err = ts.CreateTablet(context.Background(), tabCell1)
+	require.NoError(t, err)
+	err = ts.CreateTablet(context.Background(), tabCell2)
+	require.NoError(t, err)
+
+	clustersToWatch = nil
+	shardsToWatch = make(map[string][]*topodatapb.KeyRange)
+	cellsToWatch = []string{cell1}
+
+	var discoveredAliases []string
+	err = refreshTabletsUsing(ctx, func(tabletAlias string) {
+		discoveredAliases = append(discoveredAliases, tabletAlias)
+	}, true)
+	require.NoError(t, err)
+
+	assert.Contains(t, discoveredAliases, topoproto.TabletAliasString(tabCell1.Alias))
+	assert.NotContains(t, discoveredAliases, topoproto.TabletAliasString(tabCell2.Alias))
+
+	tabletFromDB, err := inst.ReadTablet(topoproto.TabletAliasString(tabCell1.Alias))
+	assert.NoError(t, err)
+	assert.NotNil(t, tabletFromDB)
+
+	_, err = inst.ReadTablet(topoproto.TabletAliasString(tabCell2.Alias))
+	assert.Error(t, err)
 }


### PR DESCRIPTION
 ## How it works

Here is [my branch in vitess](https://github.com/HubSpot/vitess/tree/cells-to-watch) with the changes
 - New `--cells_to_watch` flag registered alongside existing `--clusters_to_watch`
 - Cell filtering applied at three levels for defense in depth:
   1. `refreshTabletsUsing` — filters the cell list before fetching tablets from topo (avoids unnecessary topo calls entirely)
   2. `refreshTabletsInKeyspaceShard` — applies `shouldWatchTablet` filter before passing tablets to `refreshTablets` (this path is called during recovery and shard refreshes, and fetches by shard rather than cell)
   3. `shouldWatchTablet` — checks cell membership in addition to the existing keyspace/shard checks, so both entry points share the same filtering logic
 - When unset, defaults to watching all cells (backwards compatible)

# Testing
## Automated Testing
Added the following
 - Unit tests for `shouldWatchTablet` with cell filtering (various combinations of cells + clusters)
 - Integration test for `refreshTabletsUsing` with `cellsToWatch` set — verifies only tablets in watched cell are discovered
 - Integration test for `refreshTabletsInKeyspaceShard` with `cellsToWatch` set — verifies shard-level refresh also filters
## Verification
Branch deployed in iad03-test/vt-green and verified that only vt-green tablets are being watched

Before
```
(⎈|iad03-test:vt-green)➜  vitess-hubspot git:(cells-to-watch-hubspot) kubectl exec -i vtorc-1 -- curl -s localhost:3000/debug/vars | jq '.TabletsWatchedByCell'
Defaulted container "vtorc" out of: vtorc, auth-nginx, collectd
{
  "vt_blue": 6,
  "vt_green": 28
}
```

After
```
(⎈|iad03-test:vt-green)➜  vitess-hubspot git:(cells-to-watch-hubspot) kubectl exec -i vtorc-1 -- curl -s localhost:3000/debug/vars | jq '.TabletsWatchedByCell'                      
Defaulted container "vtorc" out of: vtorc, auth-nginx, collectd
{
  "vt_green": 28
}
```

