### PR TITLE
Port QoS from v14

### DIFF
--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1623,5 +1623,4 @@ func TestConnPoolNoResourceLeakOnTimeout(t *testing.T) {
 	if p.InUse() != 0 {
 		t.Fatalf("Expected in use connections to be 0 but were %v", p.InUse())
 	}
-
 }

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/vt/priority"
 )
 
 var (
@@ -1494,4 +1496,132 @@ func BenchmarkPoolCleanupIdleConnectionsPerformanceNoIdleConnections(b *testing.
 	for b.Loop() {
 		p.closeIdleResources(time.Now())
 	}
+}
+
+func TestRequestPriority(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	//use the only available connection in the pool
+	dbConn, err := p.Get(priority.NewContext(context.Background(), priority.Low), nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+	var executedQueries []priority.Priority
+	wg.Add(2)
+	//this will block
+	go func() {
+		defer wg.Done()
+		dbConn, err := p.Get(priority.NewContext(context.Background(), priority.Low), nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+
+		}
+		mutex.Lock()
+		defer mutex.Unlock()
+		executedQueries = append(executedQueries, priority.Low)
+		dbConn.Recycle()
+	}()
+
+	for {
+		runtime.Gosched()
+		if p.wait.waiting() == 1 {
+			break
+		}
+	}
+
+	go func() {
+		defer wg.Done()
+		dbConn, err := p.Get(priority.NewContext(context.Background(), priority.High), nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+
+		}
+		mutex.Lock()
+		defer mutex.Unlock()
+		executedQueries = append(executedQueries, priority.High)
+		dbConn.Recycle()
+	}()
+
+	for {
+		runtime.Gosched()
+		if p.wait.waiting() == 2 {
+			break
+		}
+	}
+
+	dbConn.Recycle()
+	wg.Wait()
+
+	if len(executedQueries) != 2 {
+		t.Errorf("Expected 2 queries to be executed but got %v", len(executedQueries))
+	}
+	if executedQueries[0] != priority.High {
+		t.Errorf("Expected query with highest priority to execute first but got  %v", executedQueries[0])
+	}
+	if executedQueries[1] != priority.Low {
+		t.Errorf("Expected query with lowest priority to execute second but got  %v", executedQueries[1])
+	}
+}
+
+func TestConnPoolNoResourceLeakOnTimeout(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	//use the only available connection in the pool
+	dbConn, err := p.Get(priority.NewContext(context.Background(), priority.Low), nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	// waiter 1
+	go func() {
+		defer wg.Done()
+		dbConn, err := p.Get(priority.NewContext(context.Background(), priority.Low), nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+
+		}
+		dbConn.Recycle()
+	}()
+
+	for {
+		runtime.Gosched()
+		if p.wait.waiting() == 1 {
+			break
+		}
+	}
+
+	// waiter 2 should block on the priority queue but timeout waiting on the connection
+	ctx, _ := context.WithTimeout(priority.NewContext(context.Background(), priority.High), 1*time.Second)
+
+	_, err = p.Get(ctx, nil)
+	assert.EqualError(t, err, "connection pool timed out")
+
+	//this connection should go to waiter 1
+	dbConn.Recycle()
+
+	wg.Wait()
+	if p.Available() != 1 {
+		t.Fatalf("Expected available connections to be 1 but were %v", p.Available())
+	}
+	if p.InUse() != 0 {
+		t.Fatalf("Expected in use connections to be 0 but were %v", p.InUse())
+	}
+
 }

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1609,8 +1609,8 @@ func TestConnPoolNoResourceLeakOnTimeout(t *testing.T) {
 	}
 
 	// waiter 2 should block on the priority queue but timeout waiting on the connection
-	ctx, _ := context.WithTimeout(priority.NewContext(context.Background(), priority.High), 1*time.Second)
-
+	ctx, cancel := context.WithTimeout(priority.NewContext(context.Background(), priority.High), 1*time.Second)
+	defer cancel()
 	_, err = p.Get(ctx, nil)
 	assert.EqualError(t, err, "connection pool timed out")
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/priority"
 )
 

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -207,32 +207,46 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	connSetting := conn.Conn.Setting()
 
 	wl.mu.Lock()
-
+	//we maintain the original vitess connection pool behavior that favors returning
+	//the connection to a waiter waiting for a connection with the same settings or
+	//a waiter that has reached the max age.
+	//The difference is that we do this in priority order
 	for pri := int(priority.Critical); pri >= int(priority.Penalized); pri-- {
 		queue := wl.pq.queues[pri]
 		front := queue.Front()
 		if front == nil {
 			continue
 		}
-
 		target := front
-
+		// iterate through the waitlist looking for either waiters that have been
+		// here too long, or a waiter that is looking exactly for the same Setting
+		// as the one we have in our connection.
 		for elem := front; elem != nil; elem = elem.Next() {
 			w := elem.Value
 			if w.age > maxAge || w.setting == connSetting {
 				target = elem
 				break
 			}
+			// this only ages the waiters that are being skipped over: we'll start
+			// aging the waiters in the back once they get to the front of the pool.
+			// the maxAge of 8 has been set empirically: smaller values cause clients
+			// with a specific setting to slightly starve, and aging all the clients
+			// in the list every time leads to unfairness when the system is at capacity
 			w.age++
 		}
 		wl.pq.removeElement(target)
 		wl.mu.Unlock()
 
+		// we have a target to return the connection to, simply write the connection
+		// into the waiter and signal their semaphore. they'll wake up to pick up the
+		// connection.
 		target.Value.conn = conn
 		target.Value.sema.notify(true)
 		return true
 	}
 	wl.mu.Unlock()
+	//maybe there isn't anybody to hand over the connection to, because we've
+	//raced with another client returning another connection
 	return false
 }
 

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -19,8 +19,10 @@ package smartconnpool
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"vitess.io/vitess/go/list"
+	"vitess.io/vitess/go/vt/priority"
 )
 
 // waiter represents a client waiting for a connection in the waitlist
@@ -37,12 +39,57 @@ type waiter[C Connection] struct {
 	sema semaphore
 	// age is the amount of cycles this client has been on the waitlist
 	age uint32
+	//priority is the priority of the waiter
+	priority priority.Priority
+}
+
+type priorityQueue[C Connection] struct {
+	queues                []*list.List[*waiter[C]]
+	waiterToQueuedElement map[*waiter[C]]*list.Element[*waiter[C]]
+	size                  atomic.Int64
+}
+
+func newPriorityQueue[C Connection](priorities int) *priorityQueue[C] {
+	pq := &priorityQueue[C]{
+		queues:                make([]*list.List[*waiter[C]], priorities),
+		waiterToQueuedElement: make(map[*waiter[C]]*list.Element[*waiter[C]]),
+	}
+	for i := range pq.queues {
+		pq.queues[i] = list.New[*waiter[C]]()
+	}
+	return pq
+}
+
+func (pq *priorityQueue[C]) add(waiter *waiter[C]) {
+	element := pq.queues[waiter.priority].PushBack(waiter)
+	pq.waiterToQueuedElement[waiter] = element
+	pq.size.Add(1)
+}
+
+func (pq *priorityQueue[C]) remove(waiter *waiter[C]) bool {
+	element, ok := pq.waiterToQueuedElement[waiter]
+	if !ok {
+		return false
+	}
+	pq.removeElement(element)
+	return true
+}
+
+func (pq *priorityQueue[C]) removeElement(element *list.Element[*waiter[C]]) {
+	request := element.Value
+	delete(pq.waiterToQueuedElement, request)
+	pq.queues[request.priority].Remove(element)
+	pq.size.Add(-1)
+}
+
+func (pq *priorityQueue[C]) len() int {
+	return int(pq.size.Load())
 }
 
 type waitlist[C Connection] struct {
 	nodes sync.Pool
 	mu    sync.Mutex
-	list  list.List[waiter[C]]
+	pq    *priorityQueue[C]
 }
 
 // waitForConn blocks until a connection with the given Setting is returned by another client,
@@ -53,11 +100,17 @@ type waitlist[C Connection] struct {
 func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeChan <-chan struct{}) (*Pooled[C], error) {
 	elem := wl.nodes.Get().(*list.Element[waiter[C]])
 	defer wl.nodes.Put(elem)
-	elem.Value = waiter[C]{setting: setting, conn: nil, ctx: ctx}
+
+	// Extract priority from context, default to Medium
+	pri, ok := priority.FromContext(ctx)
+	if !ok {
+		pri = priority.Medium
+	}
+
+	elem.Value = waiter[C]{setting: setting, conn: nil, ctx: ctx, priority: pri, age: 0}
 
 	wl.mu.Lock()
-	// add ourselves as a waiter at the end of the waitlist
-	wl.list.PushBackValue(elem)
+	wl.pq.add(&elem.Value)
 	wl.mu.Unlock()
 
 	done := make(chan struct{})
@@ -73,14 +126,7 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 		removed := false
 
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed = wl.pq.remove(&elem.Value)
 		wl.mu.Unlock()
 
 		// If we removed ourselves from the waitlist, we need to notify our semaphore
@@ -103,14 +149,7 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 		removed := false
 
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed = wl.pq.remove(&elem.Value)
 		wl.mu.Unlock()
 
 		// If we removed ourselves from the waitlist, we need to notify our semaphore
@@ -124,7 +163,6 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 		if removed {
 			return nil, context.Cause(ctx)
 		}
-
 		return elem.Value.conn, nil
 
 	case <-done:
@@ -133,18 +171,20 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 }
 
 func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
-	if wl.list.Len() == 0 {
-		return
+	if wl.pq.len() == 0 {
+		return 0
 	}
-
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 
-	// iterate the waitlist looking for waiters with an expired Context,
-	// or remove everything if force is true
-	for e := wl.list.Front(); e != nil; e = e.Next() {
-		if e.Value.age == 0 {
-			maybeStarving++
+	// Count waiters that have never been evaluated (age == 0).
+	// There is a race condition where a waiter checks for a connection, cannot get one, but Put returns one before they go in the waitlist
+	// proactive connection handoff by the background worker.
+	for i := 0; i < int(priority.SupportedPriorities); i++ {
+		for elem := wl.pq.queues[i].Front(); elem != nil; elem = elem.Next() {
+			if elem.Value.age == 0 {
+				maybeStarving++
+			}
 		}
 	}
 
@@ -154,7 +194,7 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 // tryReturnConn tries handing over a connection to one of the waiters in the pool.
 func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 	// fast path: if there's nobody waiting there's nothing to do
-	if wl.list.Len() == 0 {
+	if wl.pq.len() == 0 {
 		return false
 	}
 	// split the slow path into a separate function to enable inlining
@@ -163,54 +203,46 @@ func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 
 func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	const maxAge = 8
-	var (
-		target      *list.Element[waiter[D]]
-		connSetting = conn.Conn.Setting()
-	)
+
+	connSetting := conn.Conn.Setting()
 
 	wl.mu.Lock()
-	target = wl.list.Front()
-	// iterate through the waitlist looking for either waiters that have been
-	// here too long, or a waiter that is looking exactly for the same Setting
-	// as the one we have in our connection.
-	for e := target; e != nil; e = e.Next() {
-		if e.Value.age > maxAge || e.Value.setting == connSetting {
-			target = e
-			break
+
+	for pri := int(priority.Critical); pri >= int(priority.Penalized); pri-- {
+		queue := wl.pq.queues[pri]
+		front := queue.Front()
+		if front == nil {
+			continue
 		}
-		// this only ages the waiters that are being skipped over: we'll start
-		// aging the waiters in the back once they get to the front of the pool.
-		// the maxAge of 8 has been set empirically: smaller values cause clients
-		// with a specific setting to slightly starve, and aging all the clients
-		// in the list every time leads to unfairness when the system is at capacity
-		e.Value.age++
-	}
-	if target != nil {
-		wl.list.Remove(target)
+
+		target := front
+
+		for elem := front; elem != nil; elem = elem.Next() {
+			w := elem.Value
+			if w.age > maxAge || w.setting == connSetting {
+				target = elem
+				break
+			}
+			w.age++
+		}
+		wl.pq.removeElement(target)
+		wl.mu.Unlock()
+
+		target.Value.conn = conn
+		target.Value.sema.notify(true)
+		return true
 	}
 	wl.mu.Unlock()
-
-	// maybe there isn't anybody to hand over the connection to, because we've
-	// raced with another client returning another connection
-	if target == nil {
-		return false
-	}
-
-	// if we have a target to return the connection to, simply write the connection
-	// into the waiter and signal their semaphore. they'll wake up to pick up the
-	// connection.
-	target.Value.conn = conn
-	target.Value.sema.notify(true)
-	return true
+	return false
 }
 
 func (wl *waitlist[C]) init() {
 	wl.nodes.New = func() any {
 		return &list.Element[waiter[C]]{}
 	}
-	wl.list.Init()
+	wl.pq = newPriorityQueue[C](priority.SupportedPriorities)
 }
 
 func (wl *waitlist[C]) waiting() int {
-	return wl.list.Len()
+	return wl.pq.len()
 }

--- a/go/vt/priority/priority.go
+++ b/go/vt/priority/priority.go
@@ -20,7 +20,7 @@ const (
 	User
 	Critical
 
-	SupportedPriorities int = 6
+	SupportedPriorities int = int(Critical) + 1
 )
 
 func NewPriority(priority string) Priority {

--- a/go/vt/priority/priority.go
+++ b/go/vt/priority/priority.go
@@ -1,0 +1,56 @@
+package priority
+
+import (
+	"context"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+type Priority int
+
+type key int
+
+var priorityKey key = 1
+
+const (
+	Penalized Priority = iota
+	Low
+	Medium
+	High
+	User
+	Critical
+
+	SupportedPriorities int = 6
+)
+
+func NewPriority(priority string) Priority {
+	switch priority {
+	case "PENALIZED":
+		return Penalized
+	case "LOW":
+		return Low
+	case "UNKNOWN", "MEDIUM":
+		return Medium
+	case "HIGH":
+		return High
+	case "USER":
+		return User
+	case "CRITICAL":
+		return Critical
+
+	default:
+		log.Errorf("Invalid priority: %v", priority)
+		return Low
+	}
+}
+
+// NewContext adds the provided Priority to the context
+func NewContext(ctx context.Context, p Priority) context.Context {
+	return context.WithValue(ctx, priorityKey, p)
+}
+
+// FromContext returns the Priority value stored in ctx, if any.
+func FromContext(ctx context.Context) (Priority, bool) {
+	ci, ok := ctx.Value(priorityKey).(Priority)
+	return ci, ok
+}

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -70,7 +70,7 @@ const (
 
 var ErrInvalidPriority = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Invalid priority value specified in query")
 
-var queryPriorityRegex = regexp.MustCompile("/\\*vt\\+ priority: ([A-Z]+) \\*/")
+var queryPriorityRegex = regexp.MustCompile(`/\*vt\+ priority: ([A-Z]+) \*/`)
 
 func isNonSpace(r rune) bool {
 	return !unicode.IsSpace(r)

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -18,6 +18,7 @@ package sqlparser
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -68,6 +69,8 @@ const (
 )
 
 var ErrInvalidPriority = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Invalid priority value specified in query")
+
+var queryPriorityRegex = regexp.MustCompile("/\\*vt\\+ priority: ([A-Z]+) \\*/")
 
 func isNonSpace(r rune) bool {
 	return !unicode.IsSpace(r)
@@ -197,6 +200,16 @@ func StripLeadingComments(sql string) string {
 
 func hasCommentPrefix(sql string) bool {
 	return len(sql) > 1 && ((sql[0] == '/' && sql[1] == '*') || (sql[0] == '-' && sql[1] == '-'))
+}
+
+func ExtractPriority(sql string) string {
+	priority := queryPriorityRegex.FindStringSubmatch(sql)
+	if len(priority) == 2 {
+		return priority[1]
+
+	} else {
+		return "UNKNOWN"
+	}
 }
 
 // ExtractMysqlComment extracts the version and SQL from a comment-only query

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -29,7 +29,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/priority"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/priority"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -45,6 +45,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/priority"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
@@ -885,7 +886,7 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 	if transactionID != 0 && reservedID != 0 && transactionID != reservedID {
 		return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "[BUG] transactionID and reserveID must match if both are non-zero")
 	}
-
+	ctx = tsv.newContextWithPriority(ctx, sql)
 	return tsv.execute(ctx, target, sql, bindVariables, transactionID, reservedID, nil, options)
 }
 
@@ -985,7 +986,7 @@ func (tsv *TabletServer) StreamExecute(ctx context.Context, target *querypb.Targ
 	if transactionID != 0 && reservedID != 0 && transactionID != reservedID {
 		return vterrors.New(vtrpcpb.Code_INTERNAL, "[BUG] transactionID and reserveID must match if both are non-zero")
 	}
-
+	ctx = tsv.newContextWithPriority(ctx, sql)
 	return tsv.streamExecute(ctx, target, sql, bindVariables, transactionID, reservedID, nil, options, callback)
 }
 
@@ -1061,7 +1062,7 @@ func (tsv *TabletServer) BeginExecute(ctx context.Context, target *querypb.Targe
 			defer txDone()
 		}
 	}
-
+	ctx = tsv.newContextWithPriority(ctx, sql)
 	state, err := tsv.begin(ctx, target, postBeginQueries, reservedID, nil, options)
 	if err != nil {
 		return state, nil, err
@@ -1082,6 +1083,7 @@ func (tsv *TabletServer) BeginStreamExecute(
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
 ) (queryservice.TransactionState, error) {
+	ctx = tsv.newContextWithPriority(ctx, sql)
 	state, err := tsv.begin(ctx, target, postBeginQueries, reservedID, nil, options)
 	if err != nil {
 		return state, err
@@ -2147,4 +2149,14 @@ func skipQueryPlanCache(options *querypb.ExecuteOptions) bool {
 
 func (tsv *TabletServer) getShard() string {
 	return tsv.sm.Target().Shard
+}
+
+// newContextWithPriority returns a context based on query priority if QoS is enabled
+func (tsv *TabletServer) newContextWithPriority(ctx context.Context, sql string) context.Context {
+	_, present := priority.FromContext(ctx)
+	if !present {
+		return priority.NewContext(ctx, priority.NewPriority(sqlparser.ExtractPriority(sql)))
+	}
+
+	return ctx
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->
This PR is porting the HubSpot QoS code from v14 to v22. V22 has a completely different completely different connection pool implementation. It no longer uses a channel to manage resources, but uses stacks of connections and a list to manage queuing. Additionally, it doesn't have maxWaiters on the pool and lastly, when returning connections to queued goroutines it searches for ones requesting a specific settings.

The intent of this PR is to maintain as much upstream code as possible. As a result we changed the way the connection pool handles queued connections by replacing the list with a priority queue. The rest of the code is the same plumbing we used in V14


<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
