### PR TITLE
HubSpot cherry-pick from Vitess V23 -- `vtorc`: implement `restartDirectReplicas` as response to `UnreachablePrimary` (#18626)

### DIFF
--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -50,6 +50,7 @@ const (
 	ReplicaMisconfigured                   AnalysisCode = "ReplicaMisconfigured"
 	UnreachablePrimaryWithLaggingReplicas  AnalysisCode = "UnreachablePrimaryWithLaggingReplicas"
 	UnreachablePrimary                     AnalysisCode = "UnreachablePrimary"
+	UnreachablePrimaryWithBrokenReplicas   AnalysisCode = "UnreachablePrimaryWithBrokenReplicas"
 	PrimarySingleReplicaNotReplicating     AnalysisCode = "PrimarySingleReplicaNotReplicating"
 	PrimarySingleReplicaDead               AnalysisCode = "PrimarySingleReplicaDead"
 	AllPrimaryReplicasNotReplicating       AnalysisCode = "AllPrimaryReplicasNotReplicating"
@@ -145,6 +146,9 @@ type ReplicationAnalysis struct {
 	MaxReplicaGTIDErrant                      string
 	IsReadOnly                                bool
 	IsDiskStalled                             bool
+
+	AnalyzedKeyspaceEmergencyReparentDisabled bool
+	AnalyzedShardEmergencyReparentDisabled    bool
 }
 
 func (replicationAnalysis *ReplicationAnalysis) MarshalJSON() ([]byte, error) {

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -518,10 +518,15 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 			a.Analysis = UnreachablePrimaryWithLaggingReplicas
 			a.Description = "Primary cannot be reached by vtorc and all of its replicas are lagging"
 			//
-		} else if a.IsPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+		} else if a.IsPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == a.CountValidReplicas {
 			// partial success is here to reduce noise
 			a.Analysis = UnreachablePrimary
-			a.Description = "Primary cannot be reached by vtorc but it has replicating replicas; possibly a network/host issue"
+			a.Description = "Primary cannot be reached by vtorc but all of its replicas seem to be replicating; possibly a network/host issue"
+			//
+		} else if a.IsPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 && a.CountValidReplicatingReplicas < a.CountValidReplicas {
+			// partial success is here to reduce noise
+			a.Analysis = UnreachablePrimaryWithBrokenReplicas
+			a.Description = "Primary cannot be reached by vtorc but it has (some, but not all) replicating replicas; possibly a network/host issue"
 			//
 		} else if a.IsPrimary && a.SemiSyncPrimaryEnabled && a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount {
 			if isStaleBinlogCoordinates {

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -25,6 +25,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/patrickmn/go-cache"
+	"golang.org/x/sync/errgroup"
+
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -42,6 +45,8 @@ import (
 
 const (
 	CheckAndRecoverGenericProblemRecoveryName        string = "CheckAndRecoverGenericProblem"
+	RestartArbitraryDirectReplicaRecoveryName        string = "RestartArbitraryDirectReplica"
+	RestartAllDirectReplicasRecoveryName             string = "RestartAllDirectReplicas"
 	RecoverDeadPrimaryRecoveryName                   string = "RecoverDeadPrimary"
 	RecoverPrimaryTabletDeletedRecoveryName          string = "RecoverPrimaryTabletDeleted"
 	RecoverPrimaryHasPrimaryRecoveryName             string = "RecoverPrimaryHasPrimary"
@@ -66,6 +71,11 @@ var (
 	}
 
 	countPendingRecoveries = stats.NewGauge("PendingRecoveries", "Count of the number of pending recoveries")
+
+	// urgentOperations helps rate limiting some operations on replicas, such as restarting replication
+	// in an UnreachablePrimary scenario.
+	urgentOperations         *cache.Cache // key: tablet alias. value: arbitrary (we don't care)
+	urgentOperationsInterval = 1 * time.Minute
 
 	// detectedProblems is used to track the number of detected problems.
 	//
@@ -103,6 +113,8 @@ type recoveryFunction int
 const (
 	noRecoveryFunc recoveryFunction = iota
 	recoverGenericProblemFunc
+	restartArbitraryDirectReplicaFunc
+	restartAllDirectReplicasFunc
 	recoverDeadPrimaryFunc
 	recoverPrimaryTabletDeletedFunc
 	recoverPrimaryHasPrimaryFunc
@@ -168,6 +180,7 @@ func init() {
 	stats.NewGaugeFunc("ShardLocksActive", "Number of actively-held shard locks", func() int64 {
 		return atomic.LoadInt64(&shardsLockCounter)
 	})
+	urgentOperations = cache.New(urgentOperationsInterval, 2*urgentOperationsInterval)
 	go initializeTopologyRecoveryPostConfiguration()
 }
 
@@ -356,6 +369,151 @@ func checkAndRecoverGenericProblem(ctx context.Context, analysisEntry *inst.Repl
 	return false, nil, nil
 }
 
+func restartArbitraryDirectReplica(ctx context.Context, analysisEntry *inst.ReplicationAnalysis, logger *log.PrefixedLogger) (bool, *TopologyRecovery, error) {
+	return restartDirectReplicas(ctx, analysisEntry, 1, logger)
+}
+
+func restartAllDirectReplicas(ctx context.Context, analysisEntry *inst.ReplicationAnalysis, logger *log.PrefixedLogger) (bool, *TopologyRecovery, error) {
+	return restartDirectReplicas(ctx, analysisEntry, 0, logger)
+}
+
+// restartDirectReplicas restarts replication on direct replicas of an unreachable primary
+func restartDirectReplicas(ctx context.Context, analysisEntry *inst.ReplicationAnalysis, maxReplicas int, logger *log.PrefixedLogger) (bool, *TopologyRecovery, error) {
+	topologyRecovery, err := AttemptRecoveryRegistration(analysisEntry)
+	if topologyRecovery == nil {
+		message := fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another restartDirectReplicas.", analysisEntry.AnalyzedInstanceAlias)
+		logger.Warning(message)
+		_ = AuditTopologyRecovery(topologyRecovery, message)
+		return false, nil, err
+	}
+	logger.Infof("Analysis: %v, will restart direct replicas of unreachable primary %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceAlias)
+
+	// This has to be done in the end; whether successful or not, we should mark that the recovery is done.
+	defer func() {
+		_ = resolveRecovery(topologyRecovery, nil)
+	}()
+
+	// Get durability policy for the keyspace to determine semi-sync settings
+	durabilityPolicy, err := inst.GetDurabilityPolicy(analysisEntry.AnalyzedKeyspace)
+	if err != nil {
+		logger.Errorf("Error getting durability policy for keyspace %v: %v", analysisEntry.AnalyzedKeyspace, err)
+		return false, topologyRecovery, err
+	}
+
+	// Get all tablets in the shard
+	tablets, err := ts.GetTabletsByShard(ctx, analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard)
+	if err != nil {
+		logger.Errorf("Error fetching tablets for keyspace/shard %v/%v: %v", analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard, err)
+		return false, topologyRecovery, err
+	}
+
+	// Find the primary tablet for semi-sync policy determination
+	var primaryTablet *topodatapb.Tablet
+	for _, tabletInfo := range tablets {
+		tabletAlias := topoproto.TabletAliasString(tabletInfo.Tablet.Alias)
+		if tabletAlias == analysisEntry.AnalyzedInstanceAlias {
+			primaryTablet = tabletInfo.Tablet
+			break
+		}
+	}
+
+	if primaryTablet == nil {
+		logger.Errorf("Could not find primary tablet %s", analysisEntry.AnalyzedInstanceAlias)
+		return false, topologyRecovery, fmt.Errorf("could not find primary tablet %s", analysisEntry.AnalyzedInstanceAlias)
+	}
+
+	eg, _ := errgroup.WithContext(ctx)
+	var restartExpected int
+	var restartPerformed atomic.Int64
+	// Iterate through all tablets and find direct replicas of the primary.
+	// We intentionally shuffle tablet order. When maxReplicas is non-zero, we want to
+	// randomly pick which replicas to restart, to avoid biasing towards replicas.
+	for i, tabletIndex := range rand.Perm(len(tablets)) {
+		if maxReplicas > 0 && i >= maxReplicas {
+			break
+		}
+		tabletInfo := tablets[tabletIndex]
+		tablet := tabletInfo.Tablet
+		tabletAlias := topoproto.TabletAliasString(tablet.Alias)
+
+		// Skip the primary itself
+		if tabletAlias == analysisEntry.AnalyzedInstanceAlias {
+			continue
+		}
+
+		if err := urgentOperations.Add(tabletAlias, true, cache.DefaultExpiration); err != nil {
+			// Rate limit interval has not passed yet
+			continue
+		}
+
+		// Read the instance to check replication source
+		instance, found, err := inst.ReadInstance(tabletAlias)
+		if err != nil || !found {
+			logger.Warningf("Could not read instance information for %s: %v", tabletAlias, err)
+			continue
+		}
+		if instance.ReplicationDepth != 1 {
+			// Not a direct replica of the primary
+			continue
+		}
+
+		restartExpected++
+		eg.Go(func() error {
+			logger.Infof("Restarting replication on direct replica %s", tabletAlias)
+			_ = AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("Restarting replication on direct replica %s", tabletAlias))
+
+			if err := tmc.StopReplication(ctx, tablet); err != nil {
+				logger.Errorf("Failed to stop replication on %s: %v", tabletAlias, err)
+				return err
+			}
+
+			// Determine if this replica should use semi-sync based on the durability policy
+			semiSync := policy.IsReplicaSemiSync(durabilityPolicy, primaryTablet, tablet)
+
+			if err := tmc.StartReplication(ctx, tablet, semiSync); err != nil {
+				logger.Errorf("Failed to start replication on %s: %v", tabletAlias, err)
+				return err
+			}
+			logger.Infof("Successfully restarted replication on %s", tabletAlias)
+			restartPerformed.Add(1)
+			return nil
+		})
+	}
+	err = eg.Wait()
+	message := fmt.Sprintf("Completed restart of %d/%d direct replicas for unreachable primary %+v. err=%+v", restartPerformed.Load(), restartExpected, analysisEntry.AnalyzedInstanceAlias, err)
+	logger.Infof(message)
+	_ = AuditTopologyRecovery(topologyRecovery, message)
+
+	if err != nil {
+		return true, topologyRecovery, err
+	}
+
+	return true, topologyRecovery, nil
+}
+
+// isERSEnabled returns true if ERS can be used globally or for the given keyspace.
+func isERSEnabled(analysisEntry *inst.ReplicationAnalysis) bool {
+	// If ERS is disabled globally we have no way of repairing the cluster.
+	if !config.ERSEnabled() {
+		log.Infof("VTOrc not configured to run ERS, skipping recovering %v", analysisEntry.Analysis)
+		return false
+	}
+
+	// Return false if ERS is disabled on the keyspace.
+	if analysisEntry.AnalyzedKeyspaceEmergencyReparentDisabled {
+		log.Infof("ERS is disabled on keyspace %s, skipping recovering %v", analysisEntry.AnalyzedKeyspace, analysisEntry.Analysis)
+		return false
+	}
+
+	// Return false if ERS is disabled on the shard.
+	if analysisEntry.AnalyzedShardEmergencyReparentDisabled {
+		log.Infof("ERS is disabled on keyspace/shard %s, skipping recovering %v", topoproto.KeyspaceShardString(analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard), analysisEntry.Analysis)
+		return false
+	}
+
+	return true
+}
+
 // getCheckAndRecoverFunctionCode gets the recovery function code to use for the given analysis.
 func getCheckAndRecoverFunctionCode(analysisCode inst.AnalysisCode, tabletAlias string) recoveryFunction {
 	switch analysisCode {
@@ -398,7 +556,9 @@ func getCheckAndRecoverFunctionCode(analysisCode inst.AnalysisCode, tabletAlias 
 	case inst.DeadPrimaryAndReplicas:
 		return recoverGenericProblemFunc
 	case inst.UnreachablePrimary:
-		return recoverGenericProblemFunc
+		return restartArbitraryDirectReplicaFunc
+	case inst.UnreachablePrimaryWithBrokenReplicas:
+		return restartAllDirectReplicasFunc
 	case inst.UnreachablePrimaryWithLaggingReplicas:
 		return recoverGenericProblemFunc
 	case inst.AllPrimaryReplicasNotReplicating:
@@ -421,6 +581,10 @@ func hasActionableRecovery(recoveryFunctionCode recoveryFunction) bool {
 		return false
 	case recoverGenericProblemFunc:
 		return false
+	case restartArbitraryDirectReplicaFunc:
+		return true
+	case restartAllDirectReplicasFunc:
+		return true
 	case recoverDeadPrimaryFunc:
 		return true
 	case recoverPrimaryTabletDeletedFunc:
@@ -453,6 +617,10 @@ func getCheckAndRecoverFunction(recoveryFunctionCode recoveryFunction) (
 		return nil
 	case recoverGenericProblemFunc:
 		return checkAndRecoverGenericProblem
+	case restartArbitraryDirectReplicaFunc:
+		return restartArbitraryDirectReplica
+	case restartAllDirectReplicasFunc:
+		return restartAllDirectReplicas
 	case recoverDeadPrimaryFunc:
 		return recoverDeadPrimary
 	case recoverPrimaryTabletDeletedFunc:
@@ -484,6 +652,10 @@ func getRecoverFunctionName(recoveryFunctionCode recoveryFunction) string {
 		return ""
 	case recoverGenericProblemFunc:
 		return CheckAndRecoverGenericProblemRecoveryName
+	case restartArbitraryDirectReplicaFunc:
+		return RestartArbitraryDirectReplicaRecoveryName
+	case restartAllDirectReplicasFunc:
+		return RestartAllDirectReplicasRecoveryName
 	case recoverDeadPrimaryFunc:
 		return RecoverDeadPrimaryRecoveryName
 	case recoverPrimaryTabletDeletedFunc:

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -292,7 +292,27 @@ func TestGetCheckAndRecoverFunctionCode(t *testing.T) {
 			ersEnabled:                   false,
 			convertTabletWithErrantGTIDs: false,
 			analysisCode:                 inst.ErrantGTIDDetected,
-			wantRecoveryFunction:         noRecoveryFunc,
+			wantRecoveryFunction:         recoverErrantGTIDDetectedFunc,
+		}, {
+			name:                 "DeadPrimary with global ERS enabled and keyspace ERS disabled",
+			ersEnabled:           true,
+			analysisCode:         inst.DeadPrimary,
+			wantRecoveryFunction: recoverDeadPrimaryFunc,
+		}, {
+			name:                 "DeadPrimary with global+keyspace ERS enabled and shard ERS disabled",
+			ersEnabled:           true,
+			analysisCode:         inst.DeadPrimary,
+			wantRecoveryFunction: recoverDeadPrimaryFunc,
+		}, {
+			name:                 "UnreachablePrimary",
+			ersEnabled:           true,
+			analysisCode:         inst.UnreachablePrimary,
+			wantRecoveryFunction: restartArbitraryDirectReplicaFunc,
+		}, {
+			name:                 "UnreachablePrimaryWithBrokenReplicas",
+			ersEnabled:           true,
+			analysisCode:         inst.UnreachablePrimaryWithBrokenReplicas,
+			wantRecoveryFunction: restartAllDirectReplicasFunc,
 		},
 	}
 


### PR DESCRIPTION
# Description
This is a cherry-pick from Vitess 23 to fix ERS when a Primary has a stalled disk

# Testing
Tested Internally
```
I0401 15:34:26.461500       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: Analysis: DeadPrimary, RecoverDeadPrimary vt_green-0343900702
I0401 15:34:26.461523       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - will initiate emergency reparent shard in keyspace - ChaosTestgzeqqecbm85d, shard - 0
I0401 15:34:26.461526       2 topology_recovery.go:235] topology_recovery: will initiate emergency reparent shard in keyspace - ChaosTestgzeqqecbm85d, shard - 0
I0401 15:34:26.462377       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - Getting a new durability policy for semi_sync
I0401 15:34:26.463142       2 syslogger.go:133] ChaosTestgzeqqecbm85d/0 [reparent <nil> -> <nil>] reading all tablets ()
I0401 15:34:26.466284       2 syslogger.go:133] ChaosTestgzeqqecbm85d/0 [reparent <nil> -> <nil>] stop replication on all replicas ()
I0401 15:34:26.466321       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - getting replication position from vt_green-0343900702
I0401 15:34:26.466326       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - getting replication position from vt_green-0343900700
I0401 15:34:26.466328       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - getting replication position from vt_green-0343900701
W0401 15:34:26.475807       2 log.go:153] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - failed to get replication status from vt_green-0343900702: rpc error: code = Canceled desc = context canceled
I0401 15:34:26.494770       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - started finding the intermediate source
I0401 15:34:26.494889       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - finding intermediate source - sorted replica: cell:"vt_green" uid:343900700
I0401 15:34:26.494926       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - finding intermediate source - sorted replica: cell:"vt_green" uid:343900701
I0401 15:34:26.494955       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - intermediate source selected - cell:"vt_green" uid:343900700
I0401 15:34:26.494984       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - found better candidate - cell:"vt_green" uid:343900700
I0401 15:34:26.495008       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - intermediate source is ideal candidate- true
I0401 15:34:26.495037       2 syslogger.go:133] ChaosTestgzeqqecbm85d/0 [reparent <nil> -> <nil>] reparenting all tablets ()
I0401 15:34:26.495054       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - starting promotion for the new primary - vt_green-0343900700
I0401 15:34:26.495063       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - setting new primary on replica vt_green-0343900701
I0401 15:34:26.495066       2 log.go:138] Recovery for DeadPrimary on ChaosTestgzeqqecbm85d/0: ERS - setting new primary on replica vt_green-0343900702
```
