### PR TITLE
Expand tuple comparisons into nested OR/AND form before normalization

### DIFF
--- a/go/vt/sqlparser/rewrite_tuple_comparison.go
+++ b/go/vt/sqlparser/rewrite_tuple_comparison.go
@@ -1,0 +1,54 @@
+package sqlparser
+
+// ExpandTupleComparisons rewrites (a,b,c) > (x,y,z) into the nested
+// OR/AND form: (a>x OR (a=x AND (b>y OR (b=y AND c>z)))).
+// Applies to >, >=, <, <= only when LHS is all ColNames.
+func ExpandTupleComparisons(stmt Statement) Statement {
+	out := Rewrite(stmt, nil, func(cursor *Cursor) bool {
+		cmp, ok := cursor.Node().(*ComparisonExpr)
+		if !ok {
+			return true
+		}
+		if expanded, changed := expandTupleCmp(cmp); changed {
+			cursor.Replace(expanded)
+		}
+		return true
+	})
+	return out.(Statement)
+}
+
+func expandTupleCmp(cmp *ComparisonExpr) (Expr, bool) {
+	left, lok := cmp.Left.(ValTuple)
+	right, rok := cmp.Right.(ValTuple)
+	if !lok || !rok || len(left) != len(right) || len(left) < 2 {
+		return nil, false
+	}
+	switch cmp.Operator {
+	case GreaterThanOp, GreaterEqualOp, LessThanOp, LessEqualOp:
+	default:
+		return nil, false
+	}
+	for _, e := range left {
+		if _, ok := e.(*ColName); !ok {
+			return nil, false
+		}
+	}
+	return buildTupleExpansion(left, right, cmp.Operator), true
+}
+
+func buildTupleExpansion(cols, vals ValTuple, op ComparisonExprOperator) Expr {
+	if len(cols) == 1 {
+		return &ComparisonExpr{Left: cols[0], Right: vals[0], Operator: op}
+	}
+	strictOp := GreaterThanOp
+	if op == LessThanOp || op == LessEqualOp {
+		strictOp = LessThanOp
+	}
+	return &OrExpr{
+		Left: &ComparisonExpr{Left: cols[0], Right: vals[0], Operator: strictOp},
+		Right: &AndExpr{
+			Left:  &ComparisonExpr{Left: cols[0], Right: vals[0], Operator: EqualOp},
+			Right: buildTupleExpansion(cols[1:], vals[1:], op),
+		},
+	}
+}

--- a/go/vt/sqlparser/rewrite_tuple_comparison_test.go
+++ b/go/vt/sqlparser/rewrite_tuple_comparison_test.go
@@ -1,0 +1,75 @@
+package sqlparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandTupleComparisons(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		expected string
+	}{{
+		name:     "two columns greater than",
+		in:       "select * from t where (a, b) > (1, 2)",
+		expected: "select * from t where a > 1 or a = 1 and b > 2",
+	}, {
+		name:     "two columns less than",
+		in:       "select * from t where (a, b) < (1, 2)",
+		expected: "select * from t where a < 1 or a = 1 and b < 2",
+	}, {
+		name:     "two columns greater equal",
+		in:       "select * from t where (a, b) >= (1, 2)",
+		expected: "select * from t where a > 1 or a = 1 and b >= 2",
+	}, {
+		name:     "two columns less equal",
+		in:       "select * from t where (a, b) <= (1, 2)",
+		expected: "select * from t where a < 1 or a = 1 and b <= 2",
+	}, {
+		name:     "three columns greater than",
+		in:       "select * from t where (a, b, c) > (1, 2, 3)",
+		expected: "select * from t where a > 1 or a = 1 and (b > 2 or b = 2 and c > 3)",
+	}, {
+		name:     "three columns less equal",
+		in:       "select * from t where (a, b, c) <= (1, 2, 3)",
+		expected: "select * from t where a < 1 or a = 1 and (b < 2 or b = 2 and c <= 3)",
+	}, {
+		name:     "equality not expanded",
+		in:       "select * from t where (a, b) = (1, 2)",
+		expected: "select * from t where (a, b) = (1, 2)",
+	}, {
+		name:     "non-column LHS not expanded",
+		in:       "select * from t where (a + 1, b) > (1, 2)",
+		expected: "select * from t where (a + 1, b) > (1, 2)",
+	}, {
+		name:     "single element tuple not expanded",
+		in:       "select * from t where (a) > (1)",
+		expected: "select * from t where a > 1",
+	}, {
+		name:     "non-tuple comparison untouched",
+		in:       "select * from t where a > 1",
+		expected: "select * from t where a > 1",
+	}, {
+		name:     "mixed conditions",
+		in:       "select * from t where x = 1 and (a, b) > (1, 2)",
+		expected: "select * from t where x = 1 and (a > 1 or a = 1 and b > 2)",
+	}, {
+		name:     "qualified column names",
+		in:       "select * from t where (t.a, t.b) > (1, 2)",
+		expected: "select * from t where t.a > 1 or t.a = 1 and t.b > 2",
+	}}
+
+	parser := NewTestParser()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.in)
+			require.NoError(t, err)
+
+			result := ExpandTupleComparisons(stmt)
+			assert.Equal(t, tc.expected, String(result))
+		})
+	}
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -111,8 +111,9 @@ func init() {
 // the abilities of the underlying vttablets.
 type (
 	ExecutorConfig struct {
-		Normalize  bool
-		StreamSize int
+		Normalize              bool
+		ExpandTupleComparisons bool
+		StreamSize             int
 		// AllowScatter will fail planning if set to false and a plan contains any scatter queries
 		AllowScatter        bool
 		WarmingReadsPercent int
@@ -1224,6 +1225,10 @@ func (e *Executor) getCachedOrBuildPlan(
 	stmt, reservedVars, err := parseAndValidateQuery(query, e.env.Parser())
 	if err != nil {
 		return nil, false, nil, err
+	}
+
+	if e.config.ExpandTupleComparisons {
+		stmt = sqlparser.ExpandTupleComparisons(stmt)
 	}
 
 	defer func() {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -64,7 +64,8 @@ import (
 )
 
 var (
-	normalizeQueries    = true
+	normalizeQueries         = true
+	expandTupleComparisons   = false
 	streamBufferSize    = 32 * 1024
 	schemaTrackerHcName = "SchemaTracker"
 	txResolverHcName    = "TxResolver"
@@ -172,6 +173,7 @@ var (
 func registerFlags(fs *pflag.FlagSet) {
 	fs.String("transaction_mode", "MULTI", "SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit")
 	fs.BoolVar(&normalizeQueries, "normalize_queries", normalizeQueries, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
+	fs.BoolVar(&expandTupleComparisons, "expand_tuple_comparisons", expandTupleComparisons, "Expand tuple comparisons like (a,b) > (1,2) into equivalent OR/AND expressions to improve index usage.")
 	fs.BoolVar(&terseErrors, "vtgate-config-terse-errors", terseErrors, "prevent bind vars from escaping in returned errors")
 	fs.IntVar(&truncateErrorLen, "truncate-error-len", truncateErrorLen, "truncate errors sent to client if they are longer than this value (0 means do not truncate)")
 	fs.IntVar(&streamBufferSize, "stream_buffer_size", streamBufferSize, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
@@ -375,11 +377,12 @@ func Init(
 	plans := DefaultPlanCache()
 
 	eConfig := ExecutorConfig{
-		Normalize:           normalizeQueries,
-		StreamSize:          streamBufferSize,
-		AllowScatter:        !noScatter,
-		WarmingReadsPercent: warmingReadsPercent,
-		QueryLogToFile:      queryLogToFile,
+		Normalize:              normalizeQueries,
+		ExpandTupleComparisons: expandTupleComparisons,
+		StreamSize:             streamBufferSize,
+		AllowScatter:           !noScatter,
+		WarmingReadsPercent:    warmingReadsPercent,
+		QueryLogToFile:         queryLogToFile,
 	}
 
 	executor := NewExecutor(ctx, env, serv, cell, resolver, eConfig, warnShardedOnly, plans, si, pv, dynamicConfig)


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Rewrites expressions like (a,b,c) > (x,y,z) into the equivalent nested form: (a>x OR (a=x AND (b>y OR (b=y AND c>z)))). This enables MySQL to use individual column indexes instead of requiring a composite index matching the tuple order.

Applies to >, >=, <, <= operators when the LHS consists entirely of column references.

Gated behind --expand_tuple_comparisons flag (default false).


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

This is a workaround over this longstanding MySQL bug: https://bugs.mysql.com/bug.php?id=111952

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
